### PR TITLE
chore(repo): add changeset for iconify dep fix and CI changeset check

### DIFF
--- a/.changeset/fix-ui-iconify-deps.md
+++ b/.changeset/fix-ui-iconify-deps.md
@@ -1,0 +1,5 @@
+---
+"@zpress/ui": patch
+---
+
+Move `@iconify-json/logos`, `@iconify-json/material-icon-theme`, and `@iconify-json/vscode-icons` from devDependencies to dependencies so icons resolve correctly at runtime.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
@@ -21,3 +23,19 @@ jobs:
       - run: pnpm typecheck
       - run: pnpm lint
       - run: pnpm format
+
+  changeset:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+      - run: pnpm install
+      - name: Check for changeset
+        run: pnpm changeset status --since=origin/main


### PR DESCRIPTION
## Summary

- Adds missing changeset for the `@zpress/ui` iconify dependency move (`devDependencies` → `dependencies`) that was merged without one
- Adds a `changeset` status check job to CI that runs `pnpm changeset status --since=origin/main` on PRs, so future PRs without a changeset fail before merge

## Changes

- `.changeset/fix-ui-iconify-deps.md` — patch changeset for `@zpress/ui`
- `.github/workflows/ci.yml` — new `changeset` job that only runs on `pull_request` events

## Testing

- [ ] CI passes on this PR
- [ ] Changeset job runs and succeeds (this PR includes a changeset)
- [ ] Verify a PR without a changeset would fail the new check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed icon resolution at runtime by ensuring required icon packages are properly available.

* **Chores**
  * Enhanced CI/CD pipeline configuration for improved build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->