### PR TITLE
fix(packages/ui): improve mobile layout for home page hero and cards

### DIFF
--- a/.changeset/mobile-home-layout.md
+++ b/.changeset/mobile-home-layout.md
@@ -1,0 +1,14 @@
+---
+'@zpress/ui': patch
+---
+
+Fix mobile layout issues on home page
+
+- Add horizontal padding to feature grid, workspace section, and card divider so cards don't touch screen edges
+- Override hero image `max-width` from `50vw` to `90vw` on mobile for full-width display
+- Add `padding-bottom` to hero when layout wraps at 1000px breakpoint
+- Reduce hero container gap to `8px` on mobile
+- Scale down hero title, subtitle, and tagline font sizes for mobile
+- Add horizontal padding to hero content on mobile
+- Reduce hero actions gap from `1.5rem` to `1.25rem`
+- Fix hero container gap override to target correct class (`__container` instead of root)

--- a/packages/ui/src/theme/components/home/feature-card.css
+++ b/packages/ui/src/theme/components/home/feature-card.css
@@ -10,7 +10,7 @@
   gap: var(--feature-grid-gap);
   max-width: 1152px;
   margin: 0 auto;
-  padding: 0 0 64px;
+  padding: 0 16px 64px;
 }
 
 /* ── Grid item + span system ────────────────────────────────── */

--- a/packages/ui/src/theme/components/workspaces/card.css
+++ b/packages/ui/src/theme/components/workspaces/card.css
@@ -7,7 +7,7 @@
 .workspace-section {
   max-width: 1152px;
   margin: 0 auto;
-  padding: 0 0 64px;
+  padding: 0 16px 64px;
 }
 
 .workspace-section h2 {

--- a/packages/ui/src/theme/styles/overrides/home-card.css
+++ b/packages/ui/src/theme/styles/overrides/home-card.css
@@ -120,6 +120,7 @@
 .home-card-divider {
   max-width: 1152px;
   margin: 0 auto 48px;
+  padding: 0 16px;
   border: none;
   border-top: 1px solid var(--zp-c-divider);
 }

--- a/packages/ui/src/theme/styles/overrides/home.css
+++ b/packages/ui/src/theme/styles/overrides/home.css
@@ -15,7 +15,7 @@ html .rp-home-hero__image-img {
 }
 
 /* ── Rspress home hero container ────────────────────────── */
-html .rp-home-hero {
+html .rp-home-hero__container {
   gap: 16px !important;
 }
 
@@ -33,7 +33,15 @@ html .rp-home-hero__tagline {
   padding-bottom: 16px !important;
 }
 
+html .rp-home-hero__actions {
+  gap: 1.25rem !important;
+}
+
 @media (max-width: 1000px) {
+  html .rp-home-hero {
+    padding-bottom: 24px !important;
+  }
+
   html .rp-home-hero__image {
     width: 400px;
     margin-left: 0;
@@ -42,6 +50,42 @@ html .rp-home-hero__tagline {
 
   html .rp-home-hero__image-img {
     width: 400px;
+  }
+}
+
+/* ── Mobile overrides ────────────────────────────────────── */
+@media (max-width: 768px) {
+  html .rp-home-hero__container {
+    gap: 8px !important;
+  }
+
+  html .rp-home-hero__image {
+    width: 100%;
+    max-width: 90vw !important;
+    margin-left: 0;
+    margin-top: 24px;
+  }
+
+  html .rp-home-hero__image-img {
+    width: 100%;
+    max-width: 90vw !important;
+  }
+
+  html .rp-home-hero__content {
+    padding: 0 8px;
+  }
+
+  html .rp-home-hero__name {
+    font-size: 1.125rem !important;
+  }
+
+  html .rp-home-hero__text {
+    font-size: 2rem !important;
+  }
+
+  html .rp-home-hero__tagline {
+    font-size: 1rem !important;
+    line-height: 1.5 !important;
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix mobile layout issues on the home page where feature cards, workspace cards, and the divider were touching screen edges
- Fix hero image being constrained to `50vw` on mobile — now uses `90vw`
- Improve hero text sizing and spacing for mobile viewports
- Fix hero container gap override targeting the wrong Rspress class

## Changes

- **`home.css`**: Add mobile breakpoint (768px) with hero image `max-width: 90vw`, reduced container gap (`8px`), scaled-down title/subtitle/tagline sizes, content padding, and hero `padding-bottom` when stacked (1000px). Reduce actions gap to `1.25rem`. Fix gap override to target `__container`.
- **`feature-card.css`**: Add `16px` horizontal padding to `.feature-grid`
- **`card.css` (workspaces)**: Add `16px` horizontal padding to `.workspace-section`
- **`home-card.css`**: Add `16px` horizontal padding to `.home-card-divider`

## Test plan

- [ ] Verify home page on mobile viewport (~375px) — cards have gutters, hero image is near full-width
- [ ] Verify home page on tablet (~768px) — layout transitions cleanly
- [ ] Verify home page on desktop (~1280px) — no visual regressions
- [ ] Verify hero text is readable at all breakpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved mobile layout with proper spacing to prevent cards from touching screen edges.
  * Optimized hero section display for mobile devices with better image sizing and typography scaling.
  * Enhanced readability and spacing adjustments across the home page for smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->