### PR TITLE
feat(packages/theme,ui): hide appearance toggle for dark-only themes

### DIFF
--- a/.changeset/dark-only-themes.md
+++ b/.changeset/dark-only-themes.md
@@ -3,4 +3,4 @@
 '@zpress/ui': minor
 ---
 
-Add dark-only theme support to hide the appearance toggle for themes that only support dark mode (arcade, midnight)
+Add per-theme `modes` support to declare supported color modes (dark, light, or both) and hide the appearance toggle for single-mode themes like arcade and midnight

--- a/packages/theme/src/definitions.ts
+++ b/packages/theme/src/definitions.ts
@@ -49,16 +49,16 @@ export function resolveDefaultColorMode(theme: BuiltInThemeName): ColorMode {
 }
 
 /**
- * Resolve whether a built-in theme only supports dark mode.
+ * Resolve the supported color modes for a given built-in theme.
  *
  * @param theme - Built-in theme identifier
- * @returns True if the theme does not support light mode
+ * @returns The color modes the theme supports
  */
-export function resolveThemeDarkOnly(theme: BuiltInThemeName): boolean {
+export function resolveThemeModes(theme: BuiltInThemeName): readonly ('dark' | 'light')[] {
   return match(theme)
-    .with('base', () => false)
-    .with('midnight', () => true)
-    .with('arcade', () => true)
+    .with('base', () => ['dark', 'light'] as const)
+    .with('midnight', () => ['dark'] as const)
+    .with('arcade', () => ['dark'] as const)
     .exhaustive()
 }
 

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -22,7 +22,7 @@ export {
   COLOR_MODES,
   ICON_COLORS,
   resolveDefaultColorMode,
-  resolveThemeDarkOnly,
+  resolveThemeModes,
   isBuiltInTheme,
   isBuiltInIconColor,
 } from './definitions.ts'

--- a/packages/ui/src/theme/components/nav/theme-switcher.tsx
+++ b/packages/ui/src/theme/components/nav/theme-switcher.tsx
@@ -11,13 +11,13 @@ interface ThemeOption {
   readonly label: string
   readonly swatch: string
   readonly defaultColorMode: 'dark' | 'light' | 'toggle'
-  readonly darkOnly: boolean
+  readonly modes: readonly ('dark' | 'light')[]
 }
 
 const THEME_OPTIONS: readonly ThemeOption[] = [
-  { name: 'base', label: 'Base', swatch: '#a78bfa', defaultColorMode: 'toggle', darkOnly: false },
-  { name: 'midnight', label: 'Midnight', swatch: '#60a5fa', defaultColorMode: 'dark', darkOnly: true },
-  { name: 'arcade', label: 'Arcade', swatch: '#00ff88', defaultColorMode: 'dark', darkOnly: true },
+  { name: 'base', label: 'Base', swatch: '#a78bfa', defaultColorMode: 'toggle', modes: ['dark', 'light'] },
+  { name: 'midnight', label: 'Midnight', swatch: '#60a5fa', defaultColorMode: 'dark', modes: ['dark'] },
+  { name: 'arcade', label: 'Arcade', swatch: '#00ff88', defaultColorMode: 'dark', modes: ['dark'] },
 ]
 
 const VALID_THEME_NAMES = new Set(THEME_OPTIONS.map((t) => t.name))
@@ -53,11 +53,7 @@ function applyTheme(theme: ThemeOption): void {
   html.dataset.zpTheme = theme.name
   localStorage.setItem('zpress-theme', theme.name)
 
-  if (theme.darkOnly) {
-    html.dataset.zpDarkOnly = 'true'
-  } else {
-    delete html.dataset.zpDarkOnly
-  }
+  html.dataset.zpModes = theme.modes.join(' ')
 
   if (theme.defaultColorMode === 'dark') {
     // 'rp-dark' is Rspress's dark mode class; 'dark' is added for Tailwind compatibility

--- a/packages/ui/src/theme/components/theme-provider.tsx
+++ b/packages/ui/src/theme/components/theme-provider.tsx
@@ -7,9 +7,14 @@ declare const __ZPRESS_THEME_COLORS__: string
 declare const __ZPRESS_THEME_DARK_COLORS__: string
 
 /**
- * Themes that only support dark mode — the appearance toggle is hidden for these.
+ * Supported color modes per built-in theme — used to set `data-zp-modes`
+ * so the appearance toggle is hidden for single-mode themes.
  */
-const DARK_ONLY_THEMES: ReadonlySet<string> = new Set(['midnight', 'arcade'])
+const THEME_MODES: Readonly<Record<string, string>> = {
+  base: 'dark light',
+  midnight: 'dark',
+  arcade: 'dark',
+}
 
 const COLOR_VAR_MAP: Record<string, readonly string[]> = {
   brand: ['--zp-c-brand-1', '--rp-c-brand'],
@@ -172,11 +177,12 @@ export function ThemeProvider(): React.ReactElement | null {
     // 1. Set theme attribute
     html.dataset.zpTheme = themeName
 
-    // 2. Set dark-only flag — hides the appearance toggle for dark-only themes
-    if (DARK_ONLY_THEMES.has(themeName)) {
-      html.dataset.zpDarkOnly = 'true'
+    // 2. Set supported modes — hides the appearance toggle for single-mode themes
+    const modes = THEME_MODES[themeName]
+    if (modes) {
+      html.dataset.zpModes = modes
     } else {
-      delete html.dataset.zpDarkOnly
+      html.dataset.zpModes = 'dark light'
     }
 
     // 3. Force color mode if not toggle

--- a/packages/ui/src/theme/styles/overrides/rspress.css
+++ b/packages/ui/src/theme/styles/overrides/rspress.css
@@ -32,8 +32,9 @@ html .rp-button--big {
   border-radius: 9999px;
 }
 
-/* ── Dark-only themes — hide the appearance (dark/light) toggle ── */
-html[data-zp-dark-only] .rp-appearance {
+/* ── Single-mode themes — hide the appearance toggle when only one mode is supported ── */
+html[data-zp-modes='dark'] .rp-appearance,
+html[data-zp-modes='light'] .rp-appearance {
   display: none;
 }
 


### PR DESCRIPTION
## Summary

- Arcade and midnight themes do not support light mode, but the dark/light appearance toggle was still visible when using the theme switcher
- Adds a `resolveThemeDarkOnly` utility to `@zpress/theme` definitions so themes can declare they are dark-only
- Sets a `data-zp-dark-only` attribute on `<html>` which hides the Rspress `.rp-appearance` toggle via CSS

## Changes

- **`packages/theme/src/definitions.ts`** — add `resolveThemeDarkOnly(theme)` using exhaustive pattern match
- **`packages/theme/src/index.ts`** — export `resolveThemeDarkOnly`
- **`packages/ui/src/theme/components/nav/theme-switcher.tsx`** — add `darkOnly` flag to `ThemeOption`, set/remove `data-zp-dark-only` in `applyTheme`
- **`packages/ui/src/theme/components/theme-provider.tsx`** — set `data-zp-dark-only` on initial load based on active theme (including localStorage-persisted theme)
- **`packages/ui/src/theme/styles/overrides/rspress.css`** — hide `.rp-appearance` when `html[data-zp-dark-only]` is present

## Testing

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] Manual: verify toggle hidden on arcade/midnight, visible on base
- [ ] Manual: verify theme switcher transitions correctly between themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-theme color mode support: themes can now independently specify which color modes they support (dark mode, light mode, or both), enabling more flexible and customized experiences.

* **UI/UX Improvements**
  * Smart appearance toggle: the color mode switcher is automatically hidden when a theme supports only a single color mode, providing a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->