### PR TITLE
fix(packages/cli): recover gracefully from dev server restart failures

### DIFF
--- a/.changeset/fix-devmode-restart.md
+++ b/.changeset/fix-devmode-restart.md
@@ -1,0 +1,5 @@
+---
+'@zpress/cli': patch
+---
+
+Fix dev server crash on config-triggered restart failure. Previously, if the Rspress dev server failed to start after a config change, the entire process would exit. Now the watcher stays alive and logs a message so the user can fix the config and save again to retry.

--- a/packages/cli/src/lib/rspress.ts
+++ b/packages/cli/src/lib/rspress.ts
@@ -42,7 +42,7 @@ export async function startDevServer(
   // oxlint-disable-next-line functional/no-let -- mutable server instance for restart capability
   let serverInstance: ServerInstance | null = null
 
-  async function startServer(config: ZpressConfig): Promise<void> {
+  async function startServer(config: ZpressConfig): Promise<boolean> {
     const rspressConfig = createRspressConfig({ config, paths })
     try {
       serverInstance = await dev({
@@ -56,6 +56,7 @@ export async function startDevServer(
           },
         },
       })
+      return true
     } catch (error) {
       const errorMessage = (() => {
         if (error instanceof Error) {
@@ -64,12 +65,15 @@ export async function startDevServer(
         return String(error)
       })()
       process.stderr.write(`Dev server error: ${errorMessage}\n`)
-      process.exit(1)
+      return false
     }
   }
 
-  // Start initial server
-  await startServer(options.config)
+  // Start initial server — exit if it fails on first boot
+  const started = await startServer(options.config)
+  if (!started) {
+    process.exit(1)
+  }
 
   // Return callback that restarts server with new config
   return async (newConfig: ZpressConfig) => {
@@ -88,12 +92,16 @@ export async function startDevServer(
         })()
         process.stderr.write(`Error closing server: ${errorMessage}\n`)
       }
+      serverInstance = null
     }
 
     // Start new server with fresh config
-    await startServer(newConfig)
-
-    process.stdout.write('✅ Dev server restarted\n\n')
+    const restarted = await startServer(newConfig)
+    if (restarted) {
+      process.stdout.write('✅ Dev server restarted\n\n')
+    } else {
+      process.stderr.write('⚠️  Dev server failed to restart — fix the config and save again\n\n')
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix `process.exit(1)` during config-triggered dev server restarts that killed the watcher and required a full manual restart
- `startServer` now returns a boolean success flag — initial boot still exits on failure, but config-triggered restarts log the error and keep the watcher alive
- The next config file save automatically retries the server start

## Test plan

- [ ] Run `zpress dev` and verify initial startup works as before
- [ ] Edit `zpress.config.ts` with a valid change — confirm server restarts successfully
- [ ] Edit `zpress.config.ts` with an invalid change that causes Rspress to throw — confirm the process stays alive and logs `"Dev server failed to restart — fix the config and save again"`
- [ ] Fix the config and save again — confirm the server restarts on retry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dev server crash when configuration changes trigger restart failures. The watcher now continues running and logs a warning message, allowing you to correct the configuration and retry without restarting the entire development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->