### PR TITLE
fix(packages/ui,packages/cli,packages/zpress): resolve duplicate React instances in dev server

### DIFF
--- a/.changeset/fix-duplicate-react.md
+++ b/.changeset/fix-duplicate-react.md
@@ -1,0 +1,9 @@
+---
+'@zpress/ui': patch
+'@zpress/cli': patch
+'@zpress/kit': patch
+---
+
+fix(packages/ui,packages/cli,packages/zpress): resolve duplicate React instances in consumer repos
+
+Added `react` and `react-dom` resolve aliases to the Rspress builder config so rspack always uses the consumer's single React copy. Moved `react` from direct dependencies to peer dependencies in `@zpress/cli` to prevent pnpm from installing a private copy. Aligned React peer version range in `@zpress/kit` to `^19.2.5`.

--- a/examples/simple/zpress.config.ts
+++ b/examples/simple/zpress.config.ts
@@ -7,22 +7,21 @@ export default defineConfig({
   sections: [
     {
       title: 'Getting Started',
-      link: '/getting-started',
-      from: 'docs/getting-started.md',
+      path: '/getting-started',
+      include: 'docs/getting-started.md',
       icon: 'pixelarticons:speed-fast',
     },
     {
       title: 'API Reference',
-      link: '/api-reference',
-      from: 'docs/api-reference.md',
+      path: '/api-reference',
+      include: 'docs/api-reference.md',
       icon: 'pixelarticons:book-open',
     },
     {
       title: 'Guides',
-      prefix: '/guides',
-      from: 'docs/guides/*.md',
+      path: '/guides',
+      include: 'docs/guides/*.md',
       icon: 'pixelarticons:article',
-      titleFrom: 'frontmatter',
       sort: 'alpha',
     },
   ],

--- a/package.json
+++ b/package.json
@@ -64,6 +64,13 @@
     ],
     "overrides": {
       "@rsbuild/core": "2.0.0-beta.9"
+    },
+    "packageExtensions": {
+      "ink-gradient": {
+        "peerDependencies": {
+          "react": "*"
+        }
+      }
     }
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,18 +51,15 @@
     "ink": "^7.0.0",
     "ink-big-text": "^2.0.0",
     "ink-gradient": "^4.0.0",
+    "react": "^19.2.5",
     "ts-pattern": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@kidd-cli/cli": "^0.11.3",
     "@types/react": "^19.2.14",
-    "react": "^19.2.5",
     "typescript": "catalog:",
     "vitest": "catalog:"
-  },
-  "peerDependencies": {
-    "react": "^19.2.5"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,15 +51,18 @@
     "ink": "^7.0.0",
     "ink-big-text": "^2.0.0",
     "ink-gradient": "^4.0.0",
-    "react": "^19.2.5",
     "ts-pattern": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
     "@kidd-cli/cli": "^0.11.3",
     "@types/react": "^19.2.14",
+    "react": "^19.2.5",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "react": "^19.2.5"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/ui/src/config.ts
+++ b/packages/ui/src/config.ts
@@ -80,9 +80,10 @@ export function createRspressConfig(options: CreateRspressConfigOptions): UserCo
   // Without this alias, Rspress's rspack may resolve react from the
   // @zpress/ui dist/theme directory (deep inside pnpm's .pnpm store),
   // producing a second copy that triggers "Invalid hook call" errors.
-  const projectRequire = createRequire(path.join(paths.repoRoot, '_'))
-  const reactAlias = path.dirname(projectRequire.resolve('react/package.json'))
-  const reactDomAlias = path.dirname(projectRequire.resolve('react-dom/package.json'))
+  // Resolve from this package's context (react is a peer dep of @zpress/ui).
+  const selfRequire = createRequire(import.meta.url)
+  const reactAlias = path.dirname(selfRequire.resolve('react/package.json'))
+  const reactDomAlias = path.dirname(selfRequire.resolve('react-dom/package.json'))
 
   return {
     root: paths.contentDir,

--- a/packages/ui/src/config.ts
+++ b/packages/ui/src/config.ts
@@ -81,8 +81,8 @@ export function createRspressConfig(options: CreateRspressConfigOptions): UserCo
   // @zpress/ui dist/theme directory (deep inside pnpm's .pnpm store),
   // producing a second copy that triggers "Invalid hook call" errors.
   const projectRequire = createRequire(path.join(paths.repoRoot, '_'))
-  const reactAlias = projectRequire.resolve('react')
-  const reactDomAlias = projectRequire.resolve('react-dom')
+  const reactAlias = path.dirname(projectRequire.resolve('react/package.json'))
+  const reactDomAlias = path.dirname(projectRequire.resolve('react-dom/package.json'))
 
   return {
     root: paths.contentDir,

--- a/packages/ui/src/config.ts
+++ b/packages/ui/src/config.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 
 import type { UserConfig } from '@rspress/core'
@@ -75,6 +76,14 @@ export function createRspressConfig(options: CreateRspressConfigOptions): UserCo
   const isVscode = vscode === true
   const headScriptBody = buildHeadScriptBody({ colorMode, themeName, vscode: isVscode })
 
+  // Force a single React instance across all compiled theme components.
+  // Without this alias, Rspress's rspack may resolve react from the
+  // @zpress/ui dist/theme directory (deep inside pnpm's .pnpm store),
+  // producing a second copy that triggers "Invalid hook call" errors.
+  const projectRequire = createRequire(path.join(paths.repoRoot, '_'))
+  const reactAlias = projectRequire.resolve('react')
+  const reactDomAlias = projectRequire.resolve('react-dom')
+
   return {
     root: paths.contentDir,
     outDir: paths.distDir,
@@ -130,6 +139,10 @@ export function createRspressConfig(options: CreateRspressConfigOptions): UserCo
       },
       resolve: {
         alias: {
+          // Deduplicate React — pnpm isolation can cause rspack to resolve
+          // different physical copies from theme components vs Rspress internals.
+          react: reactAlias,
+          'react-dom': reactDomAlias,
           // Allow generated MDX files in .zpress/content/ to import
           // zpress React components used in landing pages.
           '@zpress/ui/theme': path.resolve(import.meta.dirname, 'theme', 'index.tsx'),

--- a/packages/zpress/package.json
+++ b/packages/zpress/package.json
@@ -53,8 +53,8 @@
   },
   "peerDependencies": {
     "@rspress/core": "catalog:",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,8 @@ catalogs:
 overrides:
   '@rsbuild/core': 2.0.0-beta.9
 
+packageExtensionsChecksum: sha256-AtLTWj5GUGjE/8XmRjVD0esu4eXUBb2n03YuDPG87h8=
+
 importers:
 
   .:
@@ -173,7 +175,7 @@ importers:
         version: 2.0.0(ink@7.0.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5))(react@19.2.5)
       ink-gradient:
         specifier: ^4.0.0
-        version: 4.0.0(ink@7.0.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5))
+        version: 4.0.0(ink@7.0.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -4345,6 +4347,7 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       ink: '>=6'
+      react: '*'
 
   ink@6.8.0:
     resolution: {integrity: sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==}
@@ -10999,11 +11002,12 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.5
 
-  ink-gradient@4.0.0(ink@7.0.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5)):
+  ink-gradient@4.0.0(ink@7.0.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5))(react@19.2.5):
     dependencies:
       '@types/gradient-string': 1.1.6
       gradient-string: 3.0.0
       ink: 7.0.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5)
+      react: 19.2.5
       strip-ansi: 7.2.0
 
   ink@6.8.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       ink-gradient:
         specifier: ^4.0.0
         version: 4.0.0(ink@7.0.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5))
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
       ts-pattern:
         specifier: 'catalog:'
         version: 5.9.0
@@ -187,9 +190,6 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
-      react:
-        specifier: ^19.2.5
-        version: 19.2.5
       typescript:
         specifier: 'catalog:'
         version: 6.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,9 +174,6 @@ importers:
       ink-gradient:
         specifier: ^4.0.0
         version: 4.0.0(ink@7.0.0(@types/react@19.2.14)(react-devtools-core@7.0.1)(react@19.2.5))
-      react:
-        specifier: ^19.2.5
-        version: 19.2.5
       ts-pattern:
         specifier: 'catalog:'
         version: 5.9.0
@@ -190,6 +187,9 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
@@ -442,11 +442,11 @@ importers:
         specifier: workspace:*
         version: link:../ui
       react:
-        specifier: ^19.2.4
-        version: 19.2.4
+        specifier: ^19.2.5
+        version: 19.2.5
       react-dom:
-        specifier: ^19.2.4
-        version: 19.2.4(react@19.2.4)
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
     devDependencies:
       '@rslib/core':
         specifier: 'catalog:'
@@ -4704,9 +4704,6 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
-  lodash-es@4.17.23:
-    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
-
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
@@ -5331,10 +5328,6 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -5431,11 +5424,6 @@ packages:
   react-devtools-core@7.0.1:
     resolution: {integrity: sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==}
 
-  react-dom@19.2.4:
-    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
-    peerDependencies:
-      react: ^19.2.4
-
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
@@ -5483,10 +5471,6 @@ packages:
     resolution: {integrity: sha512-G3bYr0BIiookpt4H05VeZUuVS/FslQAj2TeT8vDfCiL314Y+LtPXIPe/a3eamCA0wljy7z1EDYKV50Qbz7pcJg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  react@19.2.4:
-    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
-    engines: {node: '>=0.10.0'}
 
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
@@ -6028,10 +6012,6 @@ packages:
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -10611,10 +10591,6 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -11400,8 +11376,6 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
-
-  lodash-es@4.17.23: {}
 
   lodash-es@4.18.1: {}
 
@@ -12426,8 +12400,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
@@ -12614,11 +12586,6 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  react-dom@19.2.4(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-      scheduler: 0.27.0
-
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -12683,8 +12650,6 @@ snapshots:
       '@react-stately/tree': 3.9.6(react@19.2.5)
       '@react-types/shared': 3.33.1(react@19.2.5)
       react: 19.2.5
-
-  react@19.2.4: {}
 
   react@19.2.5: {}
 
@@ -13400,11 +13365,6 @@ snapshots:
   tinycolor2@1.6.0: {}
 
   tinyexec@1.1.1: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
 
   tinyglobby@0.2.16:
     dependencies:


### PR DESCRIPTION
## Summary

- Fixes "Invalid hook call" errors when running `zpress dev` in consumer repos (e.g. kidd, serenity)
- Root cause: pnpm installed a private React copy for `@zpress/cli`, creating two React instances that rspack resolved inconsistently during theme compilation

## Changes

- **`packages/ui/src/config.ts`** — Add `react` and `react-dom` resolve aliases to the Rspress builder config, forcing rspack to use the consumer's single React instance
- **`packages/cli/package.json`** — Move `react` from `dependencies` to `peerDependencies` (kept in `devDependencies`) so pnpm no longer installs a separate copy in consumer repos
- **`packages/zpress/package.json`** — Align React peer version range from `^19.2.4` to `^19.2.5`

## Test plan

- [ ] Run `zpress dev` in kidd repo — verify no "Invalid hook call" errors and dev server loads
- [ ] Run `zpress dev` in serenity repo — verify dev server loads
- [ ] Run `zpress build` in both repos — verify production build succeeds
- [ ] Verify theme components render correctly (sidebar, nav, home page)