### PR TITLE
feat(packages/cli): add crash reporter and error boundary

### DIFF
--- a/.changeset/cli-crash-reporter.md
+++ b/.changeset/cli-crash-reporter.md
@@ -1,0 +1,5 @@
+---
+'@zpress/cli': minor
+---
+
+Add crash reporter and error boundary — every CLI crash now writes a structured JSON log to a temp file and prints a one-liner fatal message pointing to it

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,8 +22,7 @@ import dump from './commands/dump.ts'
 import serve from './commands/serve.ts'
 import setup from './commands/setup.ts'
 import sync from './commands/sync.ts'
-import { reportCrash } from './lib/crash-reporter.ts'
-import type { CrashResult } from './lib/crash-reporter.ts'
+import { reportCrash, writeFatalToStderr } from './lib/crash-reporter.ts'
 import { errorBoundary } from './middleware/error-boundary.ts'
 
 declare const __KIDD_VERSION__: string
@@ -88,16 +87,3 @@ function resolveVersion(): string {
   return 'unknown'
 }
 
-/**
- * Write a fatal error message to stderr based on the crash result.
- *
- * @private
- * @param result - The CrashResult from reportCrash
- */
-function writeFatalToStderr(result: CrashResult): void {
-  if (result.ok) {
-    process.stderr.write(`\n✖ Fatal Error: ${result.message}\n  Full log: ${result.logPath}\n\n`)
-  } else {
-    process.stderr.write(`\n✖ Fatal Error: ${result.message}\n\n`)
-  }
-}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,11 +32,11 @@ declare const __KIDD_VERSION__: string
 // ---------------------------------------------------------------------------
 
 process.on('uncaughtException', (error) => {
-  handleProcessCrash(error, 'uncaughtException')
+  handleProcessCrash({ error, source: 'uncaughtException' })
 })
 
 process.on('unhandledRejection', (reason) => {
-  handleProcessCrash(reason, 'unhandledRejection')
+  handleProcessCrash({ error: reason, source: 'unhandledRejection' })
 })
 
 await cli({
@@ -56,16 +56,15 @@ await cli({
  * Handle a process-level crash (uncaughtException / unhandledRejection).
  *
  * @private
- * @param error - The caught error or rejection reason
- * @param source - Which process event caught it
+ * @param params - The caught error and which process event caught it
  */
-function handleProcessCrash(
-  error: unknown,
-  source: 'uncaughtException' | 'unhandledRejection'
-): void {
+function handleProcessCrash(params: {
+  readonly error: unknown
+  readonly source: 'uncaughtException' | 'unhandledRejection'
+}): void {
   const result = reportCrash({
-    error,
-    source,
+    error: params.error,
+    source: params.source,
     version: resolveVersion(),
   })
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,15 +22,82 @@ import dump from './commands/dump.ts'
 import serve from './commands/serve.ts'
 import setup from './commands/setup.ts'
 import sync from './commands/sync.ts'
+import { reportCrash } from './lib/crash-reporter.ts'
+import type { CrashResult } from './lib/crash-reporter.ts'
+import { errorBoundary } from './middleware/error-boundary.ts'
 
 declare const __KIDD_VERSION__: string
+
+// ---------------------------------------------------------------------------
+// Process-level safety net — catches async blowups outside the middleware chain
+// ---------------------------------------------------------------------------
+
+process.on('uncaughtException', (error) => {
+  handleProcessCrash(error, 'uncaughtException')
+})
+
+process.on('unhandledRejection', (reason) => {
+  handleProcessCrash(reason, 'unhandledRejection')
+})
 
 await cli({
   name: 'zpress',
   version: __KIDD_VERSION__,
   description: 'CLI for building and serving documentation',
+  middleware: [errorBoundary()],
   commands: { build, check, clean: cleanCmd, dev, diff, draft, dump, serve, setup, sync },
   help: {
     order: ['setup', 'dev', 'build', 'serve', 'sync', 'check', 'diff', 'draft', 'clean', 'dump'],
   },
 })
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle a process-level crash (uncaughtException / unhandledRejection).
+ *
+ * @private
+ * @param error - The caught error or rejection reason
+ * @param source - Which process event caught it
+ */
+function handleProcessCrash(
+  error: unknown,
+  source: 'uncaughtException' | 'unhandledRejection'
+): void {
+  const result = reportCrash({
+    error,
+    source,
+    version: resolveVersion(),
+  })
+
+  writeFatalToStderr(result)
+  process.exit(1)
+}
+
+/**
+ * Resolve the CLI version string at runtime, falling back to 'unknown' if the
+ * bundler constant is not available (e.g. in process-level crash handlers).
+ *
+ * @private
+ * @returns The version string
+ */
+function resolveVersion(): string {
+  if (typeof __KIDD_VERSION__ === 'string') {
+    return __KIDD_VERSION__
+  }
+  return 'unknown'
+}
+
+/**
+ * Write a fatal error message to stderr based on the crash result.
+ *
+ * @private
+ * @param result - The CrashResult from reportCrash
+ */
+function writeFatalToStderr(result: CrashResult): void {
+  if (result.ok) {
+    process.stderr.write(`\n✖ Fatal Error: ${result.message}\n  Full log: ${result.logPath}\n\n`)
+  } else {
+    process.stderr.write(`\n✖ Fatal Error: ${result.message}\n\n`)
+  }
+}

--- a/packages/cli/src/lib/crash-reporter.test.ts
+++ b/packages/cli/src/lib/crash-reporter.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // We need to mock os.tmpdir() to control the log directory
 vi.mock(import('node:os'), async (importOriginal) => {
   const original = await importOriginal()
-  return { ...original, tmpdir: vi.fn(original.tmpdir) }
+  return { ...original, tmpdir: vi.fn<typeof original.tmpdir>(original.tmpdir) }
 })
 
 const os = await import('node:os')
@@ -48,7 +48,7 @@ describe('reportCrash()', () => {
     })
 
     expect(result.logPath).not.toBeNull()
-    const contents = readFileSync(result.logPath as string, 'utf-8')
+    const contents = readFileSync(result.logPath as string, 'utf8')
     const report = JSON.parse(contents)
 
     expect(report.level).toBe('fatal')
@@ -74,7 +74,7 @@ describe('reportCrash()', () => {
     })
 
     expect(result.logPath).not.toBeNull()
-    const report = JSON.parse(readFileSync(result.logPath as string, 'utf-8'))
+    const report = JSON.parse(readFileSync(result.logPath as string, 'utf8'))
     expect(report.command).toBe('build')
     expect(report.args).toEqual({ clean: true, check: false })
   })
@@ -87,7 +87,7 @@ describe('reportCrash()', () => {
     })
 
     expect(result.logPath).not.toBeNull()
-    const report = JSON.parse(readFileSync(result.logPath as string, 'utf-8'))
+    const report = JSON.parse(readFileSync(result.logPath as string, 'utf8'))
     expect(report.command).toBeNull()
     expect(report.args).toBeNull()
   })
@@ -103,7 +103,7 @@ describe('reportCrash()', () => {
     expect(result.message).toBe('string error')
 
     expect(result.logPath).not.toBeNull()
-    const report = JSON.parse(readFileSync(result.logPath as string, 'utf-8'))
+    const report = JSON.parse(readFileSync(result.logPath as string, 'utf8'))
     expect(report.error.name).toBe('Error')
     expect(report.error.message).toBe('string error')
   })

--- a/packages/cli/src/lib/crash-reporter.test.ts
+++ b/packages/cli/src/lib/crash-reporter.test.ts
@@ -1,0 +1,145 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// We need to mock os.tmpdir() to control the log directory
+vi.mock(import('node:os'), async (importOriginal) => {
+  const original = await importOriginal()
+  return { ...original, tmpdir: vi.fn(original.tmpdir) }
+})
+
+const os = await import('node:os')
+const { reportCrash } = await import('./crash-reporter.ts')
+
+describe('reportCrash()', () => {
+  const testDir = mkdtempSync(join(tmpdir(), 'zpress-test-'))
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(os.tmpdir).mockReturnValue(testDir)
+  })
+
+  afterEach(() => {
+    rmSync(join(testDir, 'zpress'), { recursive: true, force: true })
+  })
+
+  it('should return ok: true with a logPath when write succeeds', () => {
+    const result = reportCrash({
+      error: new Error('test crash'),
+      source: 'middleware',
+      version: '0.8.4',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.message).toBe('test crash')
+    expect(result.logPath).toMatch(/\/zpress\/error-.*\.log$/)
+    expect(result.error).toBeNull()
+  })
+
+  it('should write valid JSON to the log file', () => {
+    const result = reportCrash({
+      error: new Error('json check'),
+      source: 'middleware',
+      command: 'dev',
+      args: { port: 6174 },
+      version: '0.8.4',
+    })
+
+    expect(result.logPath).not.toBeNull()
+    const contents = readFileSync(result.logPath as string, 'utf-8')
+    const report = JSON.parse(contents)
+
+    expect(report.level).toBe('fatal')
+    expect(report.source).toBe('middleware')
+    expect(report.command).toBe('dev')
+    expect(report.args).toEqual({ port: 6174 })
+    expect(report.error.name).toBe('Error')
+    expect(report.error.message).toBe('json check')
+    expect(report.error.stack).toBeDefined()
+    expect(report.env.node).toBeDefined()
+    expect(report.env.platform).toBeDefined()
+    expect(report.env.arch).toBeDefined()
+    expect(report.env.zpress).toBe('0.8.4')
+  })
+
+  it('should include command and args when provided', () => {
+    const result = reportCrash({
+      error: new Error('with context'),
+      source: 'middleware',
+      command: 'build',
+      args: { clean: true, check: false },
+      version: '0.8.4',
+    })
+
+    expect(result.logPath).not.toBeNull()
+    const report = JSON.parse(readFileSync(result.logPath as string, 'utf-8'))
+    expect(report.command).toBe('build')
+    expect(report.args).toEqual({ clean: true, check: false })
+  })
+
+  it('should set command and args to null when not provided', () => {
+    const result = reportCrash({
+      error: new Error('no context'),
+      source: 'uncaughtException',
+      version: '0.8.4',
+    })
+
+    expect(result.logPath).not.toBeNull()
+    const report = JSON.parse(readFileSync(result.logPath as string, 'utf-8'))
+    expect(report.command).toBeNull()
+    expect(report.args).toBeNull()
+  })
+
+  it('should normalize non-Error values', () => {
+    const result = reportCrash({
+      error: 'string error',
+      source: 'unhandledRejection',
+      version: '0.8.4',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.message).toBe('string error')
+
+    expect(result.logPath).not.toBeNull()
+    const report = JSON.parse(readFileSync(result.logPath as string, 'utf-8'))
+    expect(report.error.name).toBe('Error')
+    expect(report.error.message).toBe('string error')
+  })
+
+  it('should return ok: false when write fails', () => {
+    // Point tmpdir at a path that cannot be written to
+    vi.mocked(os.tmpdir).mockReturnValue('/nonexistent/readonly/path')
+
+    const result = reportCrash({
+      error: new Error('write fail'),
+      source: 'middleware',
+      version: '0.8.4',
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.message).toBe('write fail')
+    expect(result.logPath).toBeNull()
+    expect(result.error).toBeInstanceOf(Error)
+  })
+
+  it('should create unique log files for each crash', () => {
+    const result1 = reportCrash({
+      error: new Error('crash 1'),
+      source: 'middleware',
+      version: '0.8.4',
+    })
+    const result2 = reportCrash({
+      error: new Error('crash 2'),
+      source: 'middleware',
+      version: '0.8.4',
+    })
+
+    expect(result1.logPath).not.toBeNull()
+    expect(result2.logPath).not.toBeNull()
+    expect(result1.logPath).not.toBe(result2.logPath)
+    expect(existsSync(result1.logPath as string)).toBe(true)
+    expect(existsSync(result2.logPath as string)).toBe(true)
+  })
+})

--- a/packages/cli/src/lib/crash-reporter.ts
+++ b/packages/cli/src/lib/crash-reporter.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { arch, platform, version as nodeVersion } from 'node:process'
+
+import { toError } from './error.ts'
+
+/**
+ * Source of the crash — where it was caught.
+ */
+export type CrashSource = 'middleware' | 'uncaughtException' | 'unhandledRejection'
+
+/**
+ * Options for reporting a crash.
+ */
+export interface CrashReportOptions {
+  readonly error: unknown
+  readonly source: CrashSource
+  readonly command?: string
+  readonly args?: Record<string, unknown>
+  readonly version: string
+}
+
+/**
+ * Result of a crash report attempt.
+ *
+ * - `ok: true` — log written successfully, `logPath` is the file path
+ * - `ok: false` — log write failed, `error` describes why, `logPath` is null
+ *
+ * `message` is always the original error's message regardless of write outcome.
+ */
+export interface CrashResult {
+  readonly ok: boolean
+  readonly message: string
+  readonly logPath: string | null
+  readonly error: Error | null
+}
+
+/**
+ * Report a fatal crash: build a structured report and write it to disk.
+ *
+ * @param options - Crash context including the caught error, source, and optional command info
+ * @returns A CrashResult indicating whether the log was written and where
+ */
+export function reportCrash(options: CrashReportOptions): CrashResult {
+  const normalized = toError(options.error)
+  const report = buildReport(normalized, options)
+  return writeCrashLog(report, normalized.message)
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured crash report written to disk as JSON.
+ *
+ * @private
+ */
+interface CrashReport {
+  readonly timestamp: string
+  readonly level: 'fatal'
+  readonly source: CrashSource
+  readonly command: string | null
+  readonly args: Record<string, unknown> | null
+  readonly error: {
+    readonly name: string
+    readonly message: string
+    readonly stack: string | null
+  }
+  readonly env: {
+    readonly node: string
+    readonly platform: string
+    readonly arch: string
+    readonly zpress: string
+  }
+}
+
+/**
+ * Assemble a CrashReport from the normalized error and options.
+ *
+ * @private
+ * @param error - The normalized Error instance
+ * @param options - Original crash report options
+ * @returns A structured CrashReport object
+ */
+function buildReport(error: Error, options: CrashReportOptions): CrashReport {
+  return {
+    timestamp: new Date().toISOString(),
+    level: 'fatal',
+    source: options.source,
+    command: options.command ?? null,
+    args: options.args ?? null,
+    error: {
+      name: error.name,
+      message: error.message,
+      stack: error.stack ?? null,
+    },
+    env: {
+      node: nodeVersion,
+      platform: platform,
+      arch: arch,
+      zpress: options.version,
+    },
+  }
+}
+
+/**
+ * Write a crash report to a JSON file in the OS temp directory.
+ *
+ * Creates `<tmpdir>/zpress/` if it doesn't exist. Each crash gets a unique
+ * filename based on the current timestamp and a random suffix.
+ *
+ * @private
+ * @param report - The structured crash report to serialize
+ * @param message - The original error message (returned in the result)
+ * @returns A CrashResult with the write outcome
+ */
+function writeCrashLog(report: CrashReport, message: string): CrashResult {
+  try {
+    const dir = join(tmpdir(), 'zpress')
+    mkdirSync(dir, { recursive: true })
+
+    const timestamp = report.timestamp.replace(/[:.]/g, '-')
+    const filename = `error-${timestamp}-${randomUUID()}.log`
+    const logPath = join(dir, filename)
+
+    writeFileSync(logPath, JSON.stringify(report, null, 2), 'utf-8')
+
+    return { ok: true, message, logPath, error: null }
+  } catch (caught) {
+    return { ok: false, message, logPath: null, error: toError(caught) }
+  }
+}

--- a/packages/cli/src/lib/crash-reporter.ts
+++ b/packages/cli/src/lib/crash-reporter.ts
@@ -97,8 +97,8 @@ function buildReport(error: Error, options: CrashReportOptions): CrashReport {
     },
     env: {
       node: nodeVersion,
-      platform: platform,
-      arch: arch,
+      platform,
+      arch,
       zpress: options.version,
     },
   }
@@ -120,14 +120,14 @@ function writeCrashLog(report: CrashReport, message: string): CrashResult {
     const dir = join(tmpdir(), 'zpress')
     mkdirSync(dir, { recursive: true })
 
-    const timestamp = report.timestamp.replace(/[:.]/g, '-')
+    const timestamp = report.timestamp.replaceAll(/[:.]/g, '-')
     const filename = `error-${timestamp}-${randomUUID()}.log`
     const logPath = join(dir, filename)
 
-    writeFileSync(logPath, JSON.stringify(report, null, 2), 'utf-8')
+    writeFileSync(logPath, JSON.stringify(report, null, 2), 'utf8')
 
     return { ok: true, message, logPath, error: null }
-  } catch (caught) {
-    return { ok: false, message, logPath: null, error: toError(caught) }
+  } catch (error) {
+    return { ok: false, message, logPath: null, error: toError(error) }
   }
 }

--- a/packages/cli/src/lib/crash-reporter.ts
+++ b/packages/cli/src/lib/crash-reporter.ts
@@ -38,12 +38,6 @@ export interface CrashResult {
 }
 
 /**
- * Report a fatal crash: build a structured report and write it to disk.
- *
- * @param options - Crash context including the caught error, source, and optional command info
- * @returns A CrashResult indicating whether the log was written and where
- */
-/**
  * Write a fatal error message to stderr based on the crash result.
  *
  * @param result - The CrashResult from reportCrash
@@ -64,8 +58,8 @@ export function writeFatalToStderr(result: CrashResult): void {
  */
 export function reportCrash(options: CrashReportOptions): CrashResult {
   const normalized = toError(options.error)
-  const report = buildReport(normalized, options)
-  return writeCrashLog(report, normalized.message)
+  const report = buildReport({ error: normalized, options })
+  return writeCrashLog({ report, message: normalized.message })
 }
 
 // ---------------------------------------------------------------------------
@@ -98,11 +92,14 @@ interface CrashReport {
  * Assemble a CrashReport from the normalized error and options.
  *
  * @private
- * @param error - The normalized Error instance
- * @param options - Original crash report options
+ * @param params - The error and original crash report options
  * @returns A structured CrashReport object
  */
-function buildReport(error: Error, options: CrashReportOptions): CrashReport {
+function buildReport(params: {
+  readonly error: Error
+  readonly options: CrashReportOptions
+}): CrashReport {
+  const { error, options } = params
   return {
     timestamp: new Date().toISOString(),
     level: 'fatal',
@@ -130,11 +127,14 @@ function buildReport(error: Error, options: CrashReportOptions): CrashReport {
  * filename based on the current timestamp and a random suffix.
  *
  * @private
- * @param report - The structured crash report to serialize
- * @param message - The original error message (returned in the result)
+ * @param params - The report to serialize and the original error message
  * @returns A CrashResult with the write outcome
  */
-function writeCrashLog(report: CrashReport, message: string): CrashResult {
+function writeCrashLog(params: {
+  readonly report: CrashReport
+  readonly message: string
+}): CrashResult {
+  const { report, message } = params
   try {
     const dir = join(tmpdir(), 'zpress')
     mkdirSync(dir, { recursive: true, mode: 0o700 })

--- a/packages/cli/src/lib/crash-reporter.ts
+++ b/packages/cli/src/lib/crash-reporter.ts
@@ -43,6 +43,25 @@ export interface CrashResult {
  * @param options - Crash context including the caught error, source, and optional command info
  * @returns A CrashResult indicating whether the log was written and where
  */
+/**
+ * Write a fatal error message to stderr based on the crash result.
+ *
+ * @param result - The CrashResult from reportCrash
+ */
+export function writeFatalToStderr(result: CrashResult): void {
+  if (result.ok) {
+    process.stderr.write(`\n✖ Fatal Error: ${result.message}\n  Full log: ${result.logPath}\n\n`)
+  } else {
+    process.stderr.write(`\n✖ Fatal Error: ${result.message}\n\n`)
+  }
+}
+
+/**
+ * Report a fatal crash: build a structured report and write it to disk.
+ *
+ * @param options - Crash context including the caught error, source, and optional command info
+ * @returns A CrashResult indicating whether the log was written and where
+ */
 export function reportCrash(options: CrashReportOptions): CrashResult {
   const normalized = toError(options.error)
   const report = buildReport(normalized, options)
@@ -118,13 +137,13 @@ function buildReport(error: Error, options: CrashReportOptions): CrashReport {
 function writeCrashLog(report: CrashReport, message: string): CrashResult {
   try {
     const dir = join(tmpdir(), 'zpress')
-    mkdirSync(dir, { recursive: true })
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
 
     const timestamp = report.timestamp.replaceAll(/[:.]/g, '-')
     const filename = `error-${timestamp}-${randomUUID()}.log`
     const logPath = join(dir, filename)
 
-    writeFileSync(logPath, JSON.stringify(report, null, 2), 'utf8')
+    writeFileSync(logPath, JSON.stringify(report, null, 2), { encoding: 'utf8', mode: 0o600 })
 
     return { ok: true, message, logPath, error: null }
   } catch (error) {

--- a/packages/cli/src/middleware/error-boundary.ts
+++ b/packages/cli/src/middleware/error-boundary.ts
@@ -1,0 +1,49 @@
+import { middleware } from '@kidd-cli/core'
+
+import { reportCrash } from '../lib/crash-reporter.ts'
+import type { CrashResult } from '../lib/crash-reporter.ts'
+
+/**
+ * Create an error boundary middleware that catches unhandled exceptions
+ * from command handlers, writes a crash log, and exits with a fatal message.
+ *
+ * Must be registered as the **first** middleware in the `cli()` stack so
+ * it wraps the entire handler chain.
+ *
+ * @returns A kidd-cli Middleware instance
+ */
+export function errorBoundary(): ReturnType<typeof middleware> {
+  return middleware(async (ctx, next) => {
+    try {
+      await next()
+    } catch (error) {
+      const commandPath = ctx.meta.command.join(' ')
+      const result = reportCrash({
+        error,
+        source: 'middleware',
+        command: commandPath || undefined,
+        args: ctx.args as Record<string, unknown>,
+        version: ctx.meta.version,
+      })
+
+      writeFatalToStderr(result)
+      process.exit(1)
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a fatal error message to stderr based on the crash result.
+ *
+ * @private
+ * @param result - The CrashResult from reportCrash
+ */
+function writeFatalToStderr(result: CrashResult): void {
+  if (result.ok) {
+    process.stderr.write(`\n✖ Fatal Error: ${result.message}\n  Full log: ${result.logPath}\n\n`)
+  } else {
+    process.stderr.write(`\n✖ Fatal Error: ${result.message}\n\n`)
+  }
+}

--- a/packages/cli/src/middleware/error-boundary.ts
+++ b/packages/cli/src/middleware/error-boundary.ts
@@ -1,7 +1,6 @@
 import { middleware } from '@kidd-cli/core'
 
-import { reportCrash } from '../lib/crash-reporter.ts'
-import type { CrashResult } from '../lib/crash-reporter.ts'
+import { reportCrash, writeFatalToStderr } from '../lib/crash-reporter.ts'
 
 /**
  * Create an error boundary middleware that catches unhandled exceptions
@@ -30,20 +29,4 @@ export function errorBoundary(): ReturnType<typeof middleware> {
       process.exit(1)
     }
   })
-}
-
-// ---------------------------------------------------------------------------
-
-/**
- * Write a fatal error message to stderr based on the crash result.
- *
- * @private
- * @param result - The CrashResult from reportCrash
- */
-function writeFatalToStderr(result: CrashResult): void {
-  if (result.ok) {
-    process.stderr.write(`\n✖ Fatal Error: ${result.message}\n  Full log: ${result.logPath}\n\n`)
-  } else {
-    process.stderr.write(`\n✖ Fatal Error: ${result.message}\n\n`)
-  }
 }


### PR DESCRIPTION
## Summary

- Adds `reportCrash()` — writes structured JSON crash logs to `os.tmpdir()/zpress/` and returns a `CrashResult` with `ok`/`message`/`logPath`/`error`
- Adds `errorBoundary()` kidd-cli middleware that wraps the handler chain in a try/catch
- Registers `uncaughtException` / `unhandledRejection` process handlers as a safety net for async blowups outside the middleware chain (e.g. Rspress internals during dev mode)

On crash, the user sees:
```
✖ Fatal Error: Cannot read properties of undefined (reading 'sidebar')
  Full log: /tmp/zpress/error-2026-04-21T103215-a3f7c2b1.log
```

Related: joggrdocs/kidd#173 (upstream built-in version)

## Test plan

- [x] 7 unit tests for `reportCrash` (success, JSON structure, optional fields, error normalization, write failure, uniqueness)
- [x] Typecheck passes across all packages
- [x] Build succeeds — crash reporter bundled into `dist/index.mjs`
- [x] Format clean