### PR TITLE
fix(packages/cli): handle crashes in screen commands (dev mode TUI)

### DIFF
--- a/.changeset/cli-screen-crash-handler.md
+++ b/.changeset/cli-screen-crash-handler.md
@@ -1,0 +1,5 @@
+---
+'@zpress/cli': patch
+---
+
+Fix crash reporting for screen commands — errors in dev mode TUI now display in-app with crash log path and hotkeys to copy/quit

--- a/packages/cli/src/hooks/use-dev-server.ts
+++ b/packages/cli/src/hooks/use-dev-server.ts
@@ -198,11 +198,11 @@ export function useDevServer(props: UseDevServerProps): UseDevServerResult {
       set.phase('ready')
     }
 
-    init().catch((error: unknown) => {
+    init().catch((uncaught: unknown) => {
       if (disposed.current) {
         return
       }
-      const normalized = toError(error)
+      const normalized = toError(uncaught)
       const result = reportCrash({
         error: normalized,
         source: 'middleware',

--- a/packages/cli/src/hooks/use-dev-server.ts
+++ b/packages/cli/src/hooks/use-dev-server.ts
@@ -4,6 +4,8 @@ import { attemptAsync, mapValues } from 'es-toolkit'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { clean } from '../commands/clean.ts'
+import { reportCrash } from '../lib/crash-reporter.ts'
+import { toError } from '../lib/error.ts'
 import type {
   DevPhase,
   DevServerActions,
@@ -49,6 +51,7 @@ export interface UseDevServerResult {
 export function useDevServer(props: UseDevServerProps): UseDevServerResult {
   const [phase, setPhase] = useState<DevPhase>('loading')
   const [error, setError] = useState<string | null>(null)
+  const [crashLogPath, setCrashLogPath] = useState<string | null>(null)
   const [status, setStatus] = useState<WatcherStatus>('idle')
   const [lastSync, setLastSync] = useState<SyncResult | null>(null)
   const [port, setPort] = useState(0)
@@ -83,6 +86,7 @@ export function useDevServer(props: UseDevServerProps): UseDevServerResult {
     const set = guardSetters(disposed, {
       phase: setPhase,
       error: setError,
+      crashLogPath: setCrashLogPath,
       status: setStatus,
       lastSync: setLastSync,
       port: setPort,
@@ -194,7 +198,23 @@ export function useDevServer(props: UseDevServerProps): UseDevServerResult {
       set.phase('ready')
     }
 
-    init()
+    init().catch((caught: unknown) => {
+      if (disposed.current) {
+        return
+      }
+      const normalized = toError(caught)
+      const result = reportCrash({
+        error: normalized,
+        source: 'middleware',
+        command: 'dev',
+        version: 'unknown',
+      })
+      set.error(normalized.message)
+      if (result.ok) {
+        set.crashLogPath(result.logPath)
+      }
+      set.phase('error')
+    })
 
     return () => {
       // oxlint-disable-next-line functional/immutable-data -- mark disposed on unmount
@@ -210,7 +230,7 @@ export function useDevServer(props: UseDevServerProps): UseDevServerResult {
   }, [])
 
   return {
-    state: { phase, error, status, lastSync, log, port },
+    state: { phase, error, crashLogPath, status, lastSync, log, port },
     actions: { resync, clearLog, close },
   }
 }

--- a/packages/cli/src/hooks/use-dev-server.ts
+++ b/packages/cli/src/hooks/use-dev-server.ts
@@ -198,11 +198,11 @@ export function useDevServer(props: UseDevServerProps): UseDevServerResult {
       set.phase('ready')
     }
 
-    init().catch((caught: unknown) => {
+    init().catch((error: unknown) => {
       if (disposed.current) {
         return
       }
-      const normalized = toError(caught)
+      const normalized = toError(error)
       const result = reportCrash({
         error: normalized,
         source: 'middleware',

--- a/packages/cli/src/lib/dev-types.ts
+++ b/packages/cli/src/lib/dev-types.ts
@@ -26,6 +26,7 @@ export type WatcherStatus = 'idle' | 'syncing' | 'restarting' | 'error'
 export interface DevServerState {
   readonly phase: DevPhase
   readonly error: string | null
+  readonly crashLogPath: string | null
   readonly status: WatcherStatus
   readonly lastSync: SyncResult | null
   readonly log: readonly LogEntry[]

--- a/packages/cli/src/screens/dev-screen.tsx
+++ b/packages/cli/src/screens/dev-screen.tsx
@@ -1,3 +1,6 @@
+import { execSync } from 'node:child_process'
+import { platform } from 'node:os'
+
 import {
   Alert,
   Box,
@@ -10,6 +13,7 @@ import {
   useInput,
 } from '@kidd-cli/core/ui'
 import { match } from 'ts-pattern'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Banner } from '../components/banner.tsx'
 import { useDevServer } from '../hooks/use-dev-server.ts'
@@ -83,14 +87,75 @@ export function DevScreen(props: DevScreenProps): React.ReactElement {
   const width = Math.max(Math.min(columns, 80), 2)
   const separatorWidth = Math.max(width - 2, 0)
 
+  const [copied, setCopied] = useState(false)
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const handleCopy = useCallback(() => {
+    if (!state.crashLogPath) {
+      return
+    }
+    copyToClipboard(state.crashLogPath)
+    setCopied(true)
+    if (copiedTimer.current) {
+      clearTimeout(copiedTimer.current)
+    }
+    // oxlint-disable-next-line functional/immutable-data -- timer ref for auto-clear
+    copiedTimer.current = setTimeout(() => {
+      setCopied(false)
+    }, 2000)
+  }, [state.crashLogPath])
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimer.current) {
+        clearTimeout(copiedTimer.current)
+      }
+    }
+  }, [])
+
+  useInput(
+    (input, key) => {
+      if (state.phase === 'error') {
+        if (input === 'c' && state.crashLogPath) {
+          handleCopy()
+        }
+        if (input === 'q' || (key.ctrl && input === 'c')) {
+          exit()
+          process.exit(1)
+        }
+      }
+    },
+    { isActive: state.phase === 'error' }
+  )
+
   if (state.phase === 'error') {
     return (
       <Box flexDirection="column" padding={1}>
         <Banner />
         <Box marginTop={1}>
-          <Alert variant="error" title="Dev Server Error" width={width}>
+          <Alert variant="error" title="Fatal Error" width={width}>
             {state.error ?? 'Unknown error'}
           </Alert>
+        </Box>
+        {state.crashLogPath && (
+          <Box marginTop={1} paddingLeft={1} flexDirection="column">
+            <Text dimColor>Full log:</Text>
+            <Text color="cyan">{state.crashLogPath}</Text>
+          </Box>
+        )}
+        {copied && (
+          <Box marginTop={1} paddingLeft={1}>
+            <Text color="green">✓ Copied to clipboard</Text>
+          </Box>
+        )}
+        <Box marginTop={1} paddingLeft={1}>
+          {state.crashLogPath && (
+            <>
+              <HotkeyHint label="c" description="copy log path" />
+              <Text dimColor> · </Text>
+            </>
+          )}
+          <HotkeyHint label="q" description="quit" />
         </Box>
       </Box>
     )
@@ -233,4 +298,23 @@ function HotkeyHint(props: {
       <Text dimColor> {props.description}</Text>
     </Text>
   )
+}
+
+/**
+ * Copy text to the system clipboard.
+ *
+ * @private
+ * @param text - The text to copy
+ */
+function copyToClipboard(text: string): void {
+  const cmd = match(platform())
+    .with('darwin', () => 'pbcopy')
+    .with('win32', () => 'clip')
+    .otherwise(() => 'xclip -selection clipboard')
+
+  try {
+    execSync(cmd, { input: text, stdio: ['pipe', 'ignore', 'ignore'] })
+  } catch {
+    // Clipboard not available — silently ignore
+  }
 }

--- a/packages/cli/src/screens/dev-screen.tsx
+++ b/packages/cli/src/screens/dev-screen.tsx
@@ -118,17 +118,15 @@ export function DevScreen(props: DevScreenProps): React.ReactElement {
 
   useInput(
     (input, key) => {
-      if (state.phase === 'error') {
-        if (input === 'c' && state.crashLogPath) {
-          handleCopy()
-        }
-        if (input === 'q' || (key.ctrl && input === 'c')) {
-          exit()
-          process.exit(1)
-        }
+      if (input === 'q' || (key.ctrl && input === 'c')) {
+        exit()
+        process.exit(1)
+      }
+      if (input === 'c' && !key.ctrl && state.crashLogPath) {
+        handleCopy()
       }
     },
-    { isActive: state.phase === 'error' }
+    { isActive: isTTY && state.phase === 'error' }
   )
 
   if (state.phase === 'error') {

--- a/packages/cli/src/screens/dev-screen.tsx
+++ b/packages/cli/src/screens/dev-screen.tsx
@@ -81,7 +81,7 @@ export function DevScreen(props: DevScreenProps): React.ReactElement {
         })
       }
     },
-    { isActive: isTTY }
+    { isActive: isTTY && state.phase !== 'error' }
   )
 
   const width = Math.max(Math.min(columns, 80), 2)
@@ -94,7 +94,9 @@ export function DevScreen(props: DevScreenProps): React.ReactElement {
     if (!state.crashLogPath) {
       return
     }
-    copyToClipboard(state.crashLogPath)
+    if (!copyToClipboard(state.crashLogPath)) {
+      return
+    }
     setCopied(true)
     if (copiedTimer.current) {
       clearTimeout(copiedTimer.current)
@@ -306,8 +308,9 @@ function HotkeyHint(props: {
  *
  * @private
  * @param text - The text to copy
+ * @returns Whether the copy succeeded
  */
-function copyToClipboard(text: string): void {
+function copyToClipboard(text: string): boolean {
   const cmd = match(platform())
     .with('darwin', () => 'pbcopy')
     .with('win32', () => 'clip')
@@ -315,7 +318,8 @@ function copyToClipboard(text: string): void {
 
   try {
     execSync(cmd, { input: text, stdio: ['pipe', 'ignore', 'ignore'] })
+    return true
   } catch {
-    // Clipboard not available — silently ignore
+    return false
   }
 }

--- a/packages/cli/src/screens/dev-screen.tsx
+++ b/packages/cli/src/screens/dev-screen.tsx
@@ -105,13 +105,14 @@ export function DevScreen(props: DevScreenProps): React.ReactElement {
     }, 2000)
   }, [state.crashLogPath])
 
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       if (copiedTimer.current) {
         clearTimeout(copiedTimer.current)
       }
-    }
-  }, [])
+    },
+    []
+  )
 
   useInput(
     (input, key) => {


### PR DESCRIPTION
## Summary

- Ink/React silently swallows errors from async `useEffect` callbacks, bypassing both the error boundary middleware and process-level `unhandledRejection` handlers ([vadimdemedes/ink#288](https://github.com/vadimdemedes/ink/issues/288))
- Adds `.catch()` on the dev server `init()` call to funnel errors through `reportCrash` and display them in the TUI
- Redesigns the error screen with clean layout: `Fatal Error` alert, log path on its own line, hotkeys for copy (`c`) and quit (`q`)
- Adds clipboard helper with "Copied to clipboard" feedback

## Changes

- `use-dev-server.ts` — `.catch()` on `init()`, stores `crashLogPath` separately
- `dev-types.ts` — adds `crashLogPath` to `DevServerState`
- `dev-screen.tsx` — new error phase render with hotkeys, clipboard copy, feedback toast

## Test plan

- [x] Injected test throw in `init()` — error screen renders with log path
- [x] `c` copies log path to clipboard, shows "Copied to clipboard" for 2s
- [x] `q` exits with code 1
- [x] Typecheck passes
- [x] Build succeeds

## Related

- joggrdocs/kidd#174 (upstream bug: screen commands swallow errors)
- joggrdocs/kidd#163 (umbrella: crash reporting)
- joggrdocs/zpress#105 (initial crash reporter PR)