### PR TITLE
fix(examples/kitchen-sink): swap broken React.createElement logo for data URI

### DIFF
--- a/examples/kitchen-sink/ciderpress.config.ts
+++ b/examples/kitchen-sink/ciderpress.config.ts
@@ -1,12 +1,17 @@
-import React from 'react'
-import { CiderpressLogo, defineConfig } from 'ciderpress'
+import { defineConfig } from 'ciderpress'
+
+const acmeLogoSvg = (color: string): string =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 40"><text x="0" y="30" font-family="monospace" font-size="32" font-weight="700" fill="${color}">ACME</text></svg>`
 
 export default defineConfig({
   title: 'Acme Platform',
   description: 'The Acme Monorepo Documentation',
   tagline: 'Everything you need to build, ship, and scale.',
   theme: { name: 'arcade' },
-  logo: () => React.createElement(CiderpressLogo),
+  logo: ({ theme }) => ({
+    src: `data:image/svg+xml;utf8,${encodeURIComponent(acmeLogoSvg(theme.colors.brand))}`,
+    alt: 'Acme Platform',
+  }),
   home: {
     features: { truncate: { description: 2 } },
     workspaces: { columns: 2, truncate: { title: 1, description: 2 } },


### PR DESCRIPTION
## Summary

Follow-up to #119. The kitchen-sink example shipped with `logo: () => React.createElement(CiderpressLogo)` to demonstrate the function-form portal path. That form fails to load in practice because `react` isn't a direct dependency of `examples/kitchen-sink/package.json` — the config loader's Node-side resolution throws `Cannot find module 'react'` and `ciderpress dev` refuses to start.

Switching to the `LogoImage` object form keeps the function-form demo intact (proves the NavLogo portal pipeline, re-runs on theme change, reads `theme.colors.brand`) without requiring a React import in the user's config — the loader runs in Node, no JSX needed.

## Changes

`examples/kitchen-sink/ciderpress.config.ts`:

```ts
// before — fails: cannot find module 'react'
import React from 'react'
import { CiderpressLogo, defineConfig } from 'ciderpress'
logo: () => React.createElement(CiderpressLogo),

// after — works: pure object return, no react import
logo: ({ theme }) => ({
  src: `data:image/svg+xml;utf8,${encodeURIComponent(acmeLogoSvg(theme.colors.brand))}`,
  alt: 'Acme Platform',
}),
```

Renders an inline "ACME" wordmark in the active theme's brand color so the kitchen-sink example visibly differs from the auto-generated `/logo.svg` shown by `examples/simple` — making the two examples a side-by-side proof of both `logo` config paths.

## Verified

- `ciderpress dev` on examples/kitchen-sink: server starts, listens, page renders
- DOM at `/`: `.cp-nav-logo` portal mounts with `<img src="data:image/svg+xml;utf8,...ACME...">`, native title span hidden by `:has(.cp-nav-logo)` rule
- examples/simple (unchanged, no `logo` config): native `<img src="/logo.svg">` paints the auto-gen MY-LIB FIGlet, portal NOT mounted

## Test plan

- [ ] `pnpm example:kitchen-sink --headless` boots without `Cannot find module 'react'`
- [ ] Navbar shows the ACME data URI wordmark, not the ciderpress fallback