### PR TITLE
fix(packages/ui): split iconify collections into per-collection async chunks

### DIFF
--- a/.changeset/icon-collection-chunking.md
+++ b/.changeset/icon-collection-chunking.md
@@ -3,19 +3,11 @@
 'ciderpress': patch
 ---
 
-Split bundled Iconify collections into per-collection async chunks
+Load icon sets more efficiently
 
-`@ciderpress/ui` previously statically imported all nine `@iconify-json`
-collections (`logos`, `simple-icons`, `devicon`, `vscode-icons`, `mdi`,
-`skill-icons`, `catppuccin`, `material-icon-theme`, `pixelarticons`) into a
-single eager ~26MB JS chunk pulled on every route. Because that resolved to one
-module, bundler chunk-splitting could not break it apart — and a single file
-over a host's per-file cap (Cloudflare Pages rejects files >25MB) failed
-deploys outright with no config knob to slim it.
+Ciderpress no longer ships every bundled icon set to every page. Icons render
+exactly as before, but a page now loads only the icon sets it actually uses.
 
-The `Icon` component now registers each collection on demand via a per-prefix
-dynamic `import()`, so the site build emits one async chunk per collection
-(largest is `logos` at ~7MB, well under the 25MB cap) and a page only downloads
-the collections it actually references. No public API change — `<Icon icon="…" />`
-is unchanged — and any arbitrary Iconify identifier from the bundled sets still
-resolves.
+This also fixes deploys to hosts with a per-file size limit — most notably
+Cloudflare Pages, where the previous single large icon file was rejected and
+blocked the deploy.

--- a/.changeset/icon-collection-chunking.md
+++ b/.changeset/icon-collection-chunking.md
@@ -1,0 +1,21 @@
+---
+'@ciderpress/ui': patch
+'ciderpress': patch
+---
+
+Split bundled Iconify collections into per-collection async chunks
+
+`@ciderpress/ui` previously statically imported all nine `@iconify-json`
+collections (`logos`, `simple-icons`, `devicon`, `vscode-icons`, `mdi`,
+`skill-icons`, `catppuccin`, `material-icon-theme`, `pixelarticons`) into a
+single eager ~26MB JS chunk pulled on every route. Because that resolved to one
+module, bundler chunk-splitting could not break it apart — and a single file
+over a host's per-file cap (Cloudflare Pages rejects files >25MB) failed
+deploys outright with no config knob to slim it.
+
+The `Icon` component now registers each collection on demand via a per-prefix
+dynamic `import()`, so the site build emits one async chunk per collection
+(largest is `logos` at ~7MB, well under the 25MB cap) and a page only downloads
+the collections it actually references. No public API change — `<Icon icon="…" />`
+is unchanged — and any arbitrary Iconify identifier from the bundled sets still
+resolves.

--- a/packages/ui/src/theme/components/shared/icon.tsx
+++ b/packages/ui/src/theme/components/shared/icon.tsx
@@ -1,41 +1,125 @@
-import catppuccin from '@iconify-json/catppuccin/icons.json' with { type: 'json' }
-import devicon from '@iconify-json/devicon/icons.json' with { type: 'json' }
-import logos from '@iconify-json/logos/icons.json' with { type: 'json' }
-import materialIconTheme from '@iconify-json/material-icon-theme/icons.json' with { type: 'json' }
-import mdi from '@iconify-json/mdi/icons.json' with { type: 'json' }
-import pixelarticons from '@iconify-json/pixelarticons/icons.json' with { type: 'json' }
-import simpleIcons from '@iconify-json/simple-icons/icons.json' with { type: 'json' }
-import skillIcons from '@iconify-json/skill-icons/icons.json' with { type: 'json' }
-import vscodeIcons from '@iconify-json/vscode-icons/icons.json' with { type: 'json' }
-import { addCollection, Icon } from '@iconify/react'
-
-// Register all icon collections for offline Iconify resolution.
-// `addCollection` is called purely for its side effect of mutating
-// Iconify's internal registry. Holding the return values in a
-// throwaway `const` keeps the call list a single expression statement
-// rather than nine misleading named exports.
-// oxlint-disable-next-line no-unused-vars
-const _iconCollectionsLoaded = [
-  addCollection(cast(pixelarticons)),
-  addCollection(cast(devicon)),
-  addCollection(cast(mdi)),
-  addCollection(cast(simpleIcons)),
-  addCollection(cast(skillIcons)),
-  addCollection(cast(catppuccin)),
-  addCollection(cast(logos)),
-  addCollection(cast(vscodeIcons)),
-  addCollection(cast(materialIconTheme)),
-] as const
-
-export { Icon }
+import { addCollection, Icon as IconifyIcon } from '@iconify/react'
+import type { IconProps } from '@iconify/react'
+import type React from 'react'
+import { useEffect, useState } from 'react'
 
 /**
- * Cast an icon JSON import to the type expected by `addCollection`.
+ * Per-collection lazy loaders keyed by Iconify prefix.
+ *
+ * Each entry is a bare dynamic `import()` so the consuming site's Rsbuild
+ * build emits **one async chunk per collection** instead of folding all nine
+ * `icons.json` files into a single eager ~30MB chunk pulled on every route.
+ * Two consequences fall out of that:
+ *
+ * - **Deployability** — the largest collection (`logos`, ~8MB) stays well
+ *   under per-file host caps (Cloudflare Pages rejects files >25MB), where
+ *   the combined blob failed outright.
+ * - **Performance** — a page only downloads the collections it actually
+ *   references, not the full set on first paint.
+ *
+ * The specifiers are string literals (not computed) so the bundler can
+ * statically resolve every chunk at build time.
  *
  * @private
- * @param v - Raw icon JSON import
- * @returns Value cast to the addCollection parameter type
  */
-function cast(v: unknown): Parameters<typeof addCollection>[0] {
-  return v as Parameters<typeof addCollection>[0]
+const COLLECTION_LOADERS: Record<string, () => Promise<{ readonly default: unknown }>> = {
+  catppuccin: () => import('@iconify-json/catppuccin/icons.json'),
+  devicon: () => import('@iconify-json/devicon/icons.json'),
+  logos: () => import('@iconify-json/logos/icons.json'),
+  'material-icon-theme': () => import('@iconify-json/material-icon-theme/icons.json'),
+  mdi: () => import('@iconify-json/mdi/icons.json'),
+  pixelarticons: () => import('@iconify-json/pixelarticons/icons.json'),
+  'simple-icons': () => import('@iconify-json/simple-icons/icons.json'),
+  'skill-icons': () => import('@iconify-json/skill-icons/icons.json'),
+  'vscode-icons': () => import('@iconify-json/vscode-icons/icons.json'),
+}
+
+/**
+ * Cache of in-flight / settled collection registrations keyed by prefix.
+ * Guarantees each collection's chunk is fetched and merged into Iconify's
+ * registry exactly once, regardless of how many `<Icon>` instances on a
+ * page reference it.
+ *
+ * @private
+ */
+const collectionCache = new Map<string, Promise<void>>()
+
+/**
+ * Offline-registered Iconify icon.
+ *
+ * Renders `@iconify/react`'s `Icon` unchanged, but registers the icon's
+ * collection on demand: the first time a prefix is seen the matching
+ * `@iconify-json` chunk is dynamically imported and merged into Iconify's
+ * registry, then a re-render paints the resolved SVG. Because `IconifyIcon`
+ * reads the live registry on every render, an icon appears as soon as its
+ * collection chunk resolves.
+ *
+ * @param props - Standard `@iconify/react` icon props; `icon` is the
+ *   `prefix:name` identifier (e.g. `devicon:typescript`)
+ * @returns The Iconify icon element
+ */
+export function Icon(props: IconProps): React.ReactElement {
+  const prefix = resolvePrefix(props.icon)
+  const [, markRegistered] = useState(false)
+
+  useEffect(() => {
+    ensureCollection(prefix).then(() => markRegistered(true))
+  }, [prefix])
+
+  return <IconifyIcon {...props} />
+}
+
+/**
+ * Dynamically import and register the collection for a prefix, once.
+ *
+ * Returns the cached registration promise on repeat calls so the chunk is
+ * fetched a single time. Unknown prefixes (no bundled collection) resolve
+ * immediately — `IconifyIcon` falls back to its own resolution for those.
+ *
+ * @private
+ * @param prefix - Iconify collection prefix (e.g. `logos`)
+ * @returns Promise that settles once the collection is registered
+ */
+function ensureCollection(prefix: string): Promise<void> {
+  const cached = collectionCache.get(prefix)
+  if (cached !== undefined) {
+    return cached
+  }
+  const loader = COLLECTION_LOADERS[prefix]
+  if (loader === undefined) {
+    return Promise.resolve()
+  }
+  const registration = loader().then(registerModule)
+  collectionCache.set(prefix, registration)
+  return registration
+}
+
+/**
+ * Merge a dynamically imported `icons.json` module into Iconify's registry.
+ *
+ * @private
+ * @param mod - Module namespace whose `default` export is the collection JSON
+ */
+function registerModule(mod: { readonly default: unknown }): void {
+  addCollection(mod.default as Parameters<typeof addCollection>[0])
+}
+
+/**
+ * Extract the collection prefix from an Iconify identifier. Non-string icon
+ * inputs and identifiers without a `prefix:name` shape yield an empty string,
+ * which `ensureCollection` treats as "nothing to load".
+ *
+ * @private
+ * @param icon - The `icon` prop passed to `<Icon>`
+ * @returns The collection prefix, or `''` when none can be determined
+ */
+function resolvePrefix(icon: IconProps['icon']): string {
+  if (typeof icon !== 'string') {
+    return ''
+  }
+  const parts = icon.split(':')
+  if (parts.length < 2) {
+    return ''
+  }
+  return parts[0]
 }


### PR DESCRIPTION
## Summary

Fixes #127. `@ciderpress/ui` statically imported all nine `@iconify-json` collections into a single eager ~26MB JS chunk pulled on every route. Because that resolved to one module, bundler chunk-splitting (`maxSize`/`maxInitialSize`) could not break it apart, and a single file over a host's per-file cap — Cloudflare Pages rejects files >25MB — failed `wrangler pages deploy` outright, with no config knob to slim it.

The `Icon` component now registers each collection **on demand** via a per-prefix dynamic `import()`. The site's Rsbuild build already handles code-splitting on those imports with zero config changes, so each collection becomes its own async chunk and a page only downloads the collections it references.

## Changes

- `packages/ui/src/theme/components/shared/icon.tsx` — replace the nine static `icons.json` imports + eager `addCollection` side effects with a `prefix → () => import()` loader map. `<Icon>` resolves the icon's prefix, lazily imports + registers that collection once (module-level promise cache), and re-renders once it's live in Iconify's registry.
- No public API change — `<Icon icon="prefix:name" />` is unchanged, and any arbitrary Iconify identifier from the bundled sets still resolves. The existing FOUC loader masks first paint until hydration, so on-demand registration causes no visible icon pop-in.

## Testing

Built `examples/kitchen-sink` with `ciderpress build` and inspected the emitted chunks:

```
7.14MB  static/js/async/…  logos
4.91MB  static/js/async/…  devicon
4.51MB  static/js/async/…  simple-icons
3.58MB  static/js/async/…  vscode-icons
2.82MB  static/js/async/…  mdi
1.61MB  static/js/async/…  skill-icons
```

Every collection is now a separate on-demand `async/` chunk; **no output file exceeds 25MB** (largest is `logos` at ~7MB, 3.5x margin under the cap). `pnpm check` passes (typecheck + lint + format).

## Follow-up

Icon **subsetting** (emit only referenced icons at sync time → KB-scale instead of MB-scale chunks) is the larger perf win and now sits cleanly on top of this lazy loader as a pure optimization with the collection chunk as fallback. Tracking separately; not needed to clear the deploy failure this PR fixes.

## Related Issues

Closes #127