### PR TITLE
ci: build a Vercel preview on every PR

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,5 @@
   "installCommand": "pnpm install",
   "cleanUrls": true,
   "trailingSlash": false,
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ]; then exit 0; fi; [ -z \"$(pnpm ciderpress diff)\" ]"
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ]"
 }


### PR DESCRIPTION
## Summary

Preview deployments were being skipped on **every** PR. The `ignoreCommand` in `vercel.json` gated builds on `ciderpress diff`, but called it **without `--ref`** — so it fell back to `git status`, which is always empty on Vercel's clean checkout. That made the command print nothing, `[ -z "..." ]` exit `0`, and Vercel cancel the build ("Canceled by Ignored Build Step").

This drops the change-detection gate and keeps only the `changeset-release/main` skip, so every real PR builds a preview.

## Changes

`vercel.json` — `ignoreCommand`:

```diff
- "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ]; then exit 0; fi; [ -z \"$(pnpm ciderpress diff)\" ]"
+ "[ \"$VERCEL_GIT_COMMIT_REF\" = \"changeset-release/main\" ]"
```

Exits `0` (skip) only on the `changeset-release/main` version-bump branch; exits `1` (build) for everything else.

## Why not just fix `--ref`

Adding `--ref` would restore the intended "skip when docs unchanged" behavior, but that heuristic is wrong for this repo: `ciderpress diff` only watches the doc content dirs (`docs/`, `contributing/`, config), not `packages/ui` or `packages/theme`. Since the docs site is built *with* those packages, a theme/component change alters the rendered preview yet would be skipped. Dropping the gate is the correct fix; build minutes are cheap, missing previews on a docs framework are not.

## Testing

Config-only change. Verified the `ignoreCommand` logic: `[ "$VERCEL_GIT_COMMIT_REF" = "changeset-release/main" ]` returns `0` on the changeset branch (skip) and `1` otherwise (build), matching Vercel's exit-code contract.

## Related Issues

None.