### PR TITLE
fix(packages/cli): skip agent instruction files during glob discovery

### DIFF
--- a/.changeset/glob-ignore-agent-files.md
+++ b/.changeset/glob-ignore-agent-files.md
@@ -1,0 +1,16 @@
+---
+'@ciderpress/cli': patch
+'ciderpress': patch
+---
+
+Skip agent instruction files during glob discovery
+
+Content globs (`docs/**/*.md`, workspace `docs/*.md`, recursive includes, and
+`.planning/`) no longer sweep coding-agent instruction files into the site.
+`CLAUDE.md`, `AGENTS.md`, `AGENT.md`, and `GEMINI.md` are now excluded from glob
+matches.
+
+Matching is case-sensitive against the uppercase convention only — a lowercase
+`claude.md` is treated as ordinary content. Naming one of these files directly
+with a literal (non-glob) `include` still publishes it, so the deny list only
+affects glob discovery.

--- a/docs/concepts/content.md
+++ b/docs/concepts/content.md
@@ -270,6 +270,24 @@ When `discover.sort` is omitted, the `'default'` strategy is used.
 
 Global ignores in the top-level `discover.ignore` field apply to every page's auto-discovery.
 
+### Agent instruction files
+
+Coding-agent instruction files are **automatically skipped** by glob discovery, so a repo-wide pattern like `docs/**/*.md` never leaks them into your site. Matching is case-sensitive against the uppercase convention only — a lowercase `claude.md` is treated as ordinary content.
+
+| Skipped by globs (all-caps)                       | Treated as content       |
+| ------------------------------------------------- | ------------------------ |
+| `CLAUDE.md`, `AGENTS.md`, `AGENT.md`, `GEMINI.md` | `claude.md`, `readme.md` |
+
+To publish one of these files anyway, name it with a **literal** (non-glob) `include` — an explicit path is always honored, so the deny list only applies to glob matches:
+
+```ts
+{
+  title: 'Agent Guide',
+  path: '/agent-guide',
+  include: 'apps/web/CLAUDE.md', // literal path — served despite the deny list
+}
+```
+
 ### Deduplication
 
 When combining explicit `pages` with `include`, explicit entries win. If an explicit entry has the same slug as a glob-discovered file, the glob match is dropped.

--- a/examples/kitchen-sink/apps/web/docs/AGENTS.md
+++ b/examples/kitchen-sink/apps/web/docs/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+Agent instructions following the `AGENTS.md` convention. Like `CLAUDE.md`, this
+file must not appear in the built `/apps/web` section — it is swept up by the
+`docs/*.md` glob and then dropped by the agent-file deny list.

--- a/examples/kitchen-sink/apps/web/docs/CLAUDE.md
+++ b/examples/kitchen-sink/apps/web/docs/CLAUDE.md
@@ -1,0 +1,10 @@
+# CLAUDE.md
+
+Instructions for coding agents working in the Web app. This file is written for
+agents, not readers — it exists to verify that `CLAUDE.md` is skipped by the
+`docs/*.md` glob that builds the `/apps/web` section.
+
+## Conventions
+
+- Use the shared UI kit from `@acme/ui`.
+- Never edit generated route types by hand.

--- a/examples/kitchen-sink/ciderpress.config.ts
+++ b/examples/kitchen-sink/ciderpress.config.ts
@@ -130,6 +130,15 @@ export default defineConfig({
       include: 'docs/architecture.md',
     },
     {
+      // Agent-file override: `apps/web/docs/CLAUDE.md` is hidden from the
+      // `/apps/web` `docs/*.md` glob by the agent-file deny list, but a literal
+      // (non-glob) `include` names it directly and is served here on purpose.
+      title: 'Agent Guide',
+      icon: 'pixelarticons:robot',
+      path: '/agent-guide',
+      include: 'apps/web/docs/CLAUDE.md',
+    },
+    {
       title: 'Guides',
       path: '/guides',
       include: 'docs/guides/*.md',

--- a/examples/kitchen-sink/ciderpress.config.ts
+++ b/examples/kitchen-sink/ciderpress.config.ts
@@ -130,15 +130,6 @@ export default defineConfig({
       include: 'docs/architecture.md',
     },
     {
-      // Agent-file override: `apps/web/docs/CLAUDE.md` is hidden from the
-      // `/apps/web` `docs/*.md` glob by the agent-file deny list, but a literal
-      // (non-glob) `include` names it directly and is served here on purpose.
-      title: 'Agent Guide',
-      icon: 'pixelarticons:robot',
-      path: '/agent-guide',
-      include: 'apps/web/docs/CLAUDE.md',
-    },
-    {
       title: 'Guides',
       path: '/guides',
       include: 'docs/guides/*.md',
@@ -181,6 +172,16 @@ export default defineConfig({
           discover: { sort: 'alpha' },
         },
       ],
+    },
+    {
+      // Agent-file override: `apps/web/docs/CLAUDE.md` is hidden from the
+      // `/apps/web` `docs/*.md` glob by the agent-file deny list, but a literal
+      // (non-glob) `include` names it directly and is served here on purpose.
+      // Kept last so it stays out of the home's first-three feature cards.
+      title: 'Agent Guide',
+      icon: 'pixelarticons:robot',
+      path: '/agent-guide',
+      include: 'apps/web/docs/CLAUDE.md',
     },
   ],
   sidebar: {

--- a/packages/cli/src/lib/sync/agent-files.test.ts
+++ b/packages/cli/src/lib/sync/agent-files.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+
+import {
+  AGENT_INSTRUCTION_FILES,
+  excludeGlobbedAgentFiles,
+  isAgentInstructionFile,
+} from './agent-files'
+
+describe('isAgentInstructionFile()', () => {
+  it('should match known uppercase agent files', () => {
+    expect(isAgentInstructionFile('CLAUDE.md')).toBe(true)
+    expect(isAgentInstructionFile('AGENTS.md')).toBe(true)
+  })
+
+  it('should not match lowercase variants', () => {
+    expect(isAgentInstructionFile('claude.md')).toBe(false)
+    expect(isAgentInstructionFile('agents.md')).toBe(false)
+  })
+
+  it('should not match ordinary content files', () => {
+    expect(isAgentInstructionFile('README.md')).toBe(false)
+    expect(isAgentInstructionFile('guide.md')).toBe(false)
+  })
+
+  it('should keep the seed list stable', () => {
+    expect(AGENT_INSTRUCTION_FILES).toContain('CLAUDE.md')
+    expect(AGENT_INSTRUCTION_FILES).toContain('AGENTS.md')
+  })
+})
+
+describe('excludeGlobbedAgentFiles()', () => {
+  it('should drop agent files swept up by a glob', () => {
+    const files = ['docs/intro.md', 'docs/CLAUDE.md', 'docs/api/AGENTS.md']
+    expect(excludeGlobbedAgentFiles(files, ['docs/**/*.md'])).toEqual(['docs/intro.md'])
+  })
+
+  it('should keep agent files named by a literal (non-glob) include', () => {
+    const files = ['docs/CLAUDE.md']
+    expect(excludeGlobbedAgentFiles(files, ['docs/CLAUDE.md'])).toEqual(['docs/CLAUDE.md'])
+  })
+
+  it('should keep a literally-included agent file even when a glob is also present', () => {
+    const files = ['docs/intro.md', 'docs/CLAUDE.md', 'docs/api/AGENTS.md']
+    const result = excludeGlobbedAgentFiles(files, ['docs/**/*.md', 'docs/CLAUDE.md'])
+    expect(result).toEqual(['docs/intro.md', 'docs/CLAUDE.md'])
+  })
+
+  it('should leave lowercase agent-like files untouched', () => {
+    const files = ['docs/claude.md', 'docs/agents.md']
+    expect(excludeGlobbedAgentFiles(files, ['docs/**/*.md'])).toEqual(files)
+  })
+
+  it('should normalize ./ and separator differences when matching literal includes', () => {
+    const files = ['docs/CLAUDE.md']
+    expect(excludeGlobbedAgentFiles(files, ['./docs/CLAUDE.md'])).toEqual(['docs/CLAUDE.md'])
+  })
+
+  it('should return content files unchanged when none are agent files', () => {
+    const files = ['a.md', 'b/c.md']
+    expect(excludeGlobbedAgentFiles(files, ['**/*.md'])).toEqual(files)
+  })
+})

--- a/packages/cli/src/lib/sync/agent-files.ts
+++ b/packages/cli/src/lib/sync/agent-files.ts
@@ -1,0 +1,68 @@
+import path from 'node:path'
+
+import { hasGlobChars } from '@ciderpress/config'
+
+/**
+ * Bare filenames of coding-agent instruction files that must never be pulled
+ * into the docs site by a content glob.
+ *
+ * These files (Claude Code's `CLAUDE.md`, the `AGENTS.md` convention, Gemini
+ * CLI's `GEMINI.md`, etc.) live at arbitrary depths in a repo and are written
+ * for agents, not readers. Matching is case-sensitive against the uppercase
+ * convention only — a lowercase `claude.md` is treated as ordinary content,
+ * since the agent-file convention is effectively always uppercase.
+ *
+ * Extend this list to exclude additional agent instruction files.
+ */
+export const AGENT_INSTRUCTION_FILES: readonly string[] = [
+  'CLAUDE.md',
+  'AGENTS.md',
+  'AGENT.md',
+  'GEMINI.md',
+]
+
+/**
+ * Whether a bare filename is a known coding-agent instruction file.
+ *
+ * @param filename - A bare filename with no directory component (e.g. `CLAUDE.md`)
+ * @returns True when the name exactly matches an uppercase agent instruction file
+ */
+export function isAgentInstructionFile(filename: string): boolean {
+  return AGENT_INSTRUCTION_FILES.includes(filename)
+}
+
+/**
+ * Drop agent instruction files that a glob swept up, while keeping any that a
+ * literal include named directly.
+ *
+ * A glob such as `**\/*.md` should never surface `CLAUDE.md`, but an include of
+ * `docs/CLAUDE.md` (no glob metacharacters) is an explicit request and is kept.
+ *
+ * @param files - Repo-relative file paths returned by fast-glob
+ * @param patterns - The include patterns that produced `files`
+ * @returns `files` with globbed agent instruction files removed
+ */
+export function excludeGlobbedAgentFiles(
+  files: readonly string[],
+  patterns: readonly string[]
+): readonly string[] {
+  const explicit = new Set(patterns.filter((p) => !hasGlobChars(p)).map(normalizeRelative))
+
+  return files.filter((file) => {
+    if (!isAgentInstructionFile(path.basename(file))) {
+      return true
+    }
+    return explicit.has(normalizeRelative(file))
+  })
+}
+
+/**
+ * Normalize a relative path for equality comparison — POSIX separators, no `./`.
+ *
+ * @private
+ * @param p - A relative path from an include pattern or glob result
+ * @returns The normalized POSIX-style relative path
+ */
+function normalizeRelative(p: string): string {
+  return p.replace(/\\/g, '/').replace(/^\.\//, '')
+}

--- a/packages/cli/src/lib/sync/planning.ts
+++ b/packages/cli/src/lib/sync/planning.ts
@@ -6,6 +6,7 @@ import fg from 'fast-glob'
 import { groupBy } from 'massaman/array'
 import { range } from 'massaman/math'
 
+import { excludeGlobbedAgentFiles } from './agent-files.ts'
 import { linkToOutputPath } from './resolve/path.ts'
 import { deriveText, kebabToTitle } from './resolve/text.ts'
 import { stripXmlTags } from './strip-xml.ts'
@@ -46,11 +47,12 @@ export async function discoverPlanningPages(ctx: SyncContext): Promise<readonly 
     return []
   }
 
-  const files = await fg('**/*.md', {
+  const matched = await fg('**/*.md', {
     cwd: planningDir,
     onlyFiles: true,
     ignore: ['**/_*'],
   })
+  const files = excludeGlobbedAgentFiles(matched, ['**/*.md'])
 
   if (files.length === 0) {
     return []

--- a/packages/cli/src/lib/sync/resolve/index.ts
+++ b/packages/cli/src/lib/sync/resolve/index.ts
@@ -8,6 +8,7 @@ import fg from 'fast-glob'
 import { match, P } from 'massaman/match'
 import { isNil, isNotNil, isString } from 'massaman/predicate'
 
+import { excludeGlobbedAgentFiles } from '../agent-files.ts'
 import { syncError, collectResults } from '../errors.ts'
 import type { SyncError, SyncOutcome } from '../errors.ts'
 import type { ResolvedEntry, SyncContext } from '../types.ts'
@@ -349,12 +350,13 @@ async function resolveGlob(
   }
 
   const patterns = normalizeInclude(section.include)
-  const files = await fg(patterns as string[], {
+  const matched = await fg(patterns as string[], {
     cwd: ctx.repoRoot,
     ignore,
     absolute: false,
     onlyFiles: true,
   })
+  const files = excludeGlobbedAgentFiles(matched, patterns)
 
   const titleStr = resolveSectionTitle(section)
 

--- a/packages/cli/src/lib/sync/resolve/recursive.ts
+++ b/packages/cli/src/lib/sync/resolve/recursive.ts
@@ -7,6 +7,7 @@ import fg from 'fast-glob'
 import { match, P } from 'massaman/match'
 import { isNotNil } from 'massaman/predicate'
 
+import { excludeGlobbedAgentFiles } from '../agent-files.ts'
 import type { ResolvedEntry, SyncContext } from '../types.ts'
 import { extractBaseDir, linkToOutputPath, sourceExt } from './path.ts'
 import { sortEntries } from './sort.ts'
@@ -54,12 +55,13 @@ export async function resolveRecursiveGlob(
     return []
   }
 
-  const files = await fg(patterns as string[], {
+  const matched = await fg(patterns as string[], {
     cwd: ctx.repoRoot,
     ignore,
     absolute: false,
     onlyFiles: true,
   })
+  const files = excludeGlobbedAgentFiles(matched, patterns)
 
   const titleStr = resolveSectionTitle(section)
 


### PR DESCRIPTION
## Summary

Content globs were pulling coding-agent instruction files — `CLAUDE.md`, `AGENTS.md`, etc. — into the generated docs site. This adds a hardcoded, extendable deny list that filters them out of glob discovery, while still allowing a file to be published if it's named directly.

## Behavior

- **Deny list** (`AGENT_INSTRUCTION_FILES` in `packages/cli/src/lib/sync/agent-files.ts`): `CLAUDE.md`, `AGENTS.md`, `AGENT.md`, `GEMINI.md` — edit the array to extend.
- **All-caps only** — matching is case-sensitive; a lowercase `claude.md` is treated as ordinary content (the agent-file convention is effectively always uppercase).
- **Literal includes override** — the filter only applies to files matched by a glob. An `include` with no glob metacharacters (e.g. `apps/web/CLAUDE.md`) names the file directly and is always honored.

Applied to all three content glob-discovery sites: non-recursive includes (`resolveGlob`), recursive includes (`resolveRecursiveGlob`), and `.planning/` discovery.

## Changes

- `packages/cli` — new `agent-files.ts` helper (`isAgentInstructionFile`, `excludeGlobbedAgentFiles`) wired into the three `fast-glob` call sites; reuses `hasGlobChars` from `@ciderpress/config` to detect literal vs glob patterns.
- Unit tests covering all-caps matching, glob exclusion, and the literal-include override.
- `examples/kitchen-sink` — nested `apps/web/docs/CLAUDE.md` + `AGENTS.md` fixtures (excluded from the `/apps/web` glob) plus an **Agent Guide** page that pulls `CLAUDE.md` in via a literal `include` to demonstrate the override.
- Docs — new "Agent instruction files" note under content auto-discovery.

## Testing

- `ciderpress sync` on kitchen-sink: `/apps/web` synced content contains only its 3 real docs (CLAUDE.md/AGENTS.md excluded); the override page `agent-guide.md` is present with the CLAUDE.md content.
- `pnpm --filter @ciderpress/cli test` — 189 passing (10 new).
- `pnpm check` — typecheck + lint + format clean (16/16).