### PR TITLE
feat(packages/ui): config to disable the "Was this page helpful?" feedback widget

### DIFF
--- a/.changeset/feedback-config-toggle.md
+++ b/.changeset/feedback-config-toggle.md
@@ -1,0 +1,11 @@
+---
+'@ciderpress/config': minor
+'@ciderpress/ui': minor
+---
+
+Add `feedback` config to toggle the "Was this page helpful?" widget.
+
+The widget is enabled by default. Set `feedback: false` to disable it site-wide, or `feedback: { question: '...' }` to customise the question text.
+
+- **`@ciderpress/config`** — new `feedback?: false | { question?: string }` field on `CiderpressConfig`; matching `feedbackConfigSchema` exported from `@ciderpress/config`.
+- **`@ciderpress/ui`** — `SiteBlock` and `CiderpressSiteBlock` gain a `feedback: { enabled, question }` field; `Layout` conditionally renders `<Feedback />` based on the resolved value.

--- a/.changeset/feedback-config-toggle.md
+++ b/.changeset/feedback-config-toggle.md
@@ -5,7 +5,7 @@
 
 Add `feedback` config to toggle the "Was this page helpful?" widget.
 
-The widget is enabled by default. Set `feedback: false` to disable it site-wide, or `feedback: { question: '...' }` to customise the question text.
+The widget is off by default. Set `feedback: true` to enable it with the default question, or `feedback: { question: '...' }` to enable it with custom text.
 
-- **`@ciderpress/config`** — new `feedback?: false | FeedbackConfig` field on `CiderpressConfig`, with an exported `FeedbackConfig` type.
-- **`@ciderpress/ui`** — `SiteBlock` and `CiderpressSiteBlock` gain a `feedback: { enabled, question }` field; `Layout` conditionally renders `<Feedback />` based on the resolved value.
+- **`@ciderpress/config`** — new `feedback?: boolean | FeedbackConfig` field on `CiderpressConfig`, with an exported `FeedbackConfig` type.
+- **`@ciderpress/ui`** — `SiteBlock` and `CiderpressSiteBlock` gain a `feedback: { enabled, question }` field; `Layout` renders `<Feedback />` only when feedback is enabled.

--- a/.changeset/feedback-config-toggle.md
+++ b/.changeset/feedback-config-toggle.md
@@ -7,5 +7,5 @@ Add `feedback` config to toggle the "Was this page helpful?" widget.
 
 The widget is enabled by default. Set `feedback: false` to disable it site-wide, or `feedback: { question: '...' }` to customise the question text.
 
-- **`@ciderpress/config`** — new `feedback?: false | { question?: string }` field on `CiderpressConfig`; matching `feedbackConfigSchema` exported from `@ciderpress/config`.
+- **`@ciderpress/config`** — new `feedback?: false | FeedbackConfig` field on `CiderpressConfig`, with an exported `FeedbackConfig` type.
 - **`@ciderpress/ui`** — `SiteBlock` and `CiderpressSiteBlock` gain a `feedback: { enabled, question }` field; `Layout` conditionally renders `<Feedback />` based on the resolved value.

--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -721,6 +721,27 @@ reportLink: { repo: 'acme/docs' },
 reportLink: false,
 ```
 
+## `feedback`
+
+Controls the "Was this page helpful?" yes/no widget rendered at the bottom of every doc page. Enabled by default.
+
+```ts
+feedback?: false | { question?: string }
+```
+
+| Value               | Effect                                   |
+| ------------------- | ---------------------------------------- |
+| omitted / `{}`      | Widget renders with the default question |
+| `{ question: '…' }` | Widget renders with a custom question    |
+| `false`             | Widget does not render                   |
+
+```ts
+// custom question
+feedback: { question: 'Did this help?' },
+// disable site-wide
+feedback: false,
+```
+
 ## `home`
 
 Home page layout — hero, proof strip, features grid, showcase grid, split section, final CTA, and the render-order layout list.

--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -723,23 +723,23 @@ reportLink: false,
 
 ## `feedback`
 
-Controls the "Was this page helpful?" yes/no widget rendered at the bottom of every doc page. Enabled by default.
+Controls the "Was this page helpful?" yes/no widget rendered at the bottom of every doc page. Off by default.
 
 ```ts
-feedback?: false | { question?: string }
+feedback?: boolean | { question?: string }
 ```
 
 | Value               | Effect                                   |
 | ------------------- | ---------------------------------------- |
-| omitted / `{}`      | Widget renders with the default question |
+| omitted / `false`   | Widget does not render                   |
+| `true`              | Widget renders with the default question |
 | `{ question: '…' }` | Widget renders with a custom question    |
-| `false`             | Widget does not render                   |
 
 ```ts
-// custom question
+// enable with the default question
+feedback: true,
+// enable with a custom question
 feedback: { question: 'Did this help?' },
-// disable site-wide
-feedback: false,
 ```
 
 ## `home`

--- a/packages/config/schemas/schema.json
+++ b/packages/config/schemas/schema.json
@@ -1946,11 +1946,9 @@
       ]
     },
     "feedback": {
-      "default": {},
       "anyOf": [
         {
-          "type": "boolean",
-          "const": false
+          "type": "boolean"
         },
         {
           "type": "object",

--- a/packages/config/schemas/schema.json
+++ b/packages/config/schemas/schema.json
@@ -1946,6 +1946,7 @@
       ]
     },
     "feedback": {
+      "default": {},
       "anyOf": [
         {
           "type": "boolean",

--- a/packages/config/schemas/schema.json
+++ b/packages/config/schemas/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/thebytefarm/ciderpress/v1.0.0-rc.4/packages/config/schemas/schema.json",
+  "$id": "https://raw.githubusercontent.com/thebytefarm/ciderpress/v1.0.0-rc.5/packages/config/schemas/schema.json",
   "title": "Ciderpress Configuration",
   "description": "Configuration file for ciderpress documentation framework",
   "type": "object",
@@ -1940,6 +1940,23 @@
             },
             "url": {},
             "onResolve": {}
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "feedback": {
+      "anyOf": [
+        {
+          "type": "boolean",
+          "const": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "question": {
+              "type": "string"
+            }
           },
           "additionalProperties": false
         }

--- a/packages/config/scripts/generate-schema.ts
+++ b/packages/config/scripts/generate-schema.ts
@@ -10,9 +10,14 @@ const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { versi
 const currentVersion = packageJson.version
 
 try {
+  // `io: 'input'` emits the schema for the config a user *writes*, not the
+  // parsed output. Fields carrying a `.default()` stay optional (a default
+  // means "you may omit it") while still surfacing their `default` value for
+  // editor hints — the 'output' target would instead mark them `required`.
   const rawJsonSchema = z.toJSONSchema(ciderpressConfigSchema, {
     target: 'draft-7',
     unrepresentable: 'any',
+    io: 'input',
   })
   const jsonSchema = applyTupleLengthBounds(rawJsonSchema) as Record<string, unknown>
 

--- a/packages/config/scripts/generate-schema.ts
+++ b/packages/config/scripts/generate-schema.ts
@@ -10,14 +10,9 @@ const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { versi
 const currentVersion = packageJson.version
 
 try {
-  // `io: 'input'` emits the schema for the config a user *writes*, not the
-  // parsed output. Fields carrying a `.default()` stay optional (a default
-  // means "you may omit it") while still surfacing their `default` value for
-  // editor hints — the 'output' target would instead mark them `required`.
   const rawJsonSchema = z.toJSONSchema(ciderpressConfigSchema, {
     target: 'draft-7',
     unrepresentable: 'any',
-    io: 'input',
   })
   const jsonSchema = applyTupleLengthBounds(rawJsonSchema) as Record<string, unknown>
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -72,7 +72,7 @@ export type {
 
 export { defineConfig } from './define-config.ts'
 export { validateConfig } from './validator.ts'
-export { ciderpressConfigSchema, feedbackConfigSchema, pathsSchema } from './schema.ts'
+export { ciderpressConfigSchema, pathsSchema } from './schema.ts'
 
 export { configError, configErrorFromZod, configWarning } from './errors.ts'
 export type {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -37,6 +37,7 @@ export type {
   CopyrightConfig,
   EditLinkConfig,
   ReportLinkConfig,
+  FeedbackConfig,
   DiscoverConfig,
   ResolvedPage,
   ResolvedSection,
@@ -71,7 +72,7 @@ export type {
 
 export { defineConfig } from './define-config.ts'
 export { validateConfig } from './validator.ts'
-export { ciderpressConfigSchema, pathsSchema } from './schema.ts'
+export { ciderpressConfigSchema, feedbackConfigSchema, pathsSchema } from './schema.ts'
 
 export { configError, configErrorFromZod, configWarning } from './errors.ts'
 export type {

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -569,7 +569,7 @@ const reportLinkConfigSchema = z
   })
   .strict()
 
-export const feedbackConfigSchema = z
+const feedbackConfigSchema = z
   .object({
     question: z.string().optional(),
   })

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -39,6 +39,7 @@ import type {
   DiscoverConfig,
   EditLinkConfig,
   Feature,
+  FeedbackConfig,
   FooterColumn,
   FooterConfig,
   Frontmatter,
@@ -568,6 +569,12 @@ const reportLinkConfigSchema = z
   })
   .strict()
 
+export const feedbackConfigSchema = z
+  .object({
+    question: z.string().optional(),
+  })
+  .strict()
+
 const discoverConfigSchema = z
   .object({
     ignore: z.array(z.string()).optional(),
@@ -695,6 +702,7 @@ export const ciderpressConfigSchema = z
     footer: footerConfigSchema.optional(),
     editLink: z.union([z.literal(false), editLinkConfigSchema]).optional(),
     reportLink: z.union([z.literal(false), reportLinkConfigSchema]).optional(),
+    feedback: z.union([z.literal(false), feedbackConfigSchema]).optional(),
     home: homeConfigSchema.optional(),
     discover: discoverConfigSchema.optional(),
     templates: z.union([z.string(), z.array(z.string())]).optional(),
@@ -811,6 +819,8 @@ const _guardOpenAPISpec: z.ZodType<OpenAPISpec> = openAPISpecSchema
 const _guardDiscoverConfig: z.ZodType<DiscoverConfig> = discoverConfigSchema
 // oxlint-disable-next-line no-unused-vars -- compile-time type guard
 const _guardDevServerConfig: z.ZodType<DevServerConfig> = devServerConfigSchema
+// oxlint-disable-next-line no-unused-vars -- compile-time type guard
+const _guardFeedbackConfig: z.ZodType<FeedbackConfig> = feedbackConfigSchema
 // oxlint-disable-next-line no-unused-vars -- compile-time type guard
 const _guardTruncateConfig: z.ZodType<TruncateConfig> = truncateConfigSchema
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -702,7 +702,11 @@ export const ciderpressConfigSchema = z
     footer: footerConfigSchema.optional(),
     editLink: z.union([z.literal(false), editLinkConfigSchema]).optional(),
     reportLink: z.union([z.literal(false), reportLinkConfigSchema]).optional(),
-    feedback: z.union([z.literal(false), feedbackConfigSchema]).optional(),
+    // Feedback is the one block that is ENABLED by default (edit/report are
+    // off-by-absence). `.default({})` makes that explicit at parse time so
+    // consumers reading config directly through `@ciderpress/config` see the
+    // resolved "enabled" value instead of a bare `undefined`.
+    feedback: z.union([z.literal(false), feedbackConfigSchema]).default({}),
     home: homeConfigSchema.optional(),
     discover: discoverConfigSchema.optional(),
     templates: z.union([z.string(), z.array(z.string())]).optional(),

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -702,11 +702,7 @@ export const ciderpressConfigSchema = z
     footer: footerConfigSchema.optional(),
     editLink: z.union([z.literal(false), editLinkConfigSchema]).optional(),
     reportLink: z.union([z.literal(false), reportLinkConfigSchema]).optional(),
-    // Feedback is the one block that is ENABLED by default (edit/report are
-    // off-by-absence). `.default({})` makes that explicit at parse time so
-    // consumers reading config directly through `@ciderpress/config` see the
-    // resolved "enabled" value instead of a bare `undefined`.
-    feedback: z.union([z.literal(false), feedbackConfigSchema]).default({}),
+    feedback: z.union([z.boolean(), feedbackConfigSchema]).optional(),
     home: homeConfigSchema.optional(),
     discover: discoverConfigSchema.optional(),
     templates: z.union([z.string(), z.array(z.string())]).optional(),

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1224,8 +1224,8 @@ export interface FooterConfig {
  * Feedback widget configuration.
  *
  * Controls the "Was this page helpful?" yes/no widget rendered at the
- * bottom of every doc page. Set `feedback` to `false` to disable the
- * widget site-wide.
+ * bottom of every doc page. The widget is off by default; passing an
+ * object (or `feedback: true`) enables it.
  */
 export interface FeedbackConfig {
   /**
@@ -1637,13 +1637,11 @@ export interface CiderpressConfig {
   readonly reportLink?: false | ReportLinkConfig
   /**
    * "Was this page helpful?" feedback widget rendered under every doc page.
-   * Enabled by default — omitting it (or passing `{}`) renders the widget
-   * with the default question. Set to `false` to disable site-wide, or pass
-   * an object to customise the question text.
-   *
-   * @default {}
+   * Off by default. Set `feedback: true` to enable it with the default
+   * question, or pass an object to enable it with a custom question.
+   * `false` (or omitting it) keeps the widget hidden.
    */
-  readonly feedback?: false | FeedbackConfig
+  readonly feedback?: boolean | FeedbackConfig
   /**
    * Home page configuration — hero, proof, features, showcase, split,
    * cta, and render order.

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1637,8 +1637,11 @@ export interface CiderpressConfig {
   readonly reportLink?: false | ReportLinkConfig
   /**
    * "Was this page helpful?" feedback widget rendered under every doc page.
-   * Enabled by default. Set to `false` to disable site-wide, or pass an
-   * object to customise the question text.
+   * Enabled by default — omitting it (or passing `{}`) renders the widget
+   * with the default question. Set to `false` to disable site-wide, or pass
+   * an object to customise the question text.
+   *
+   * @default {}
    */
   readonly feedback?: false | FeedbackConfig
   /**

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1221,6 +1221,22 @@ export interface FooterConfig {
 }
 
 /**
+ * Feedback widget configuration.
+ *
+ * Controls the "Was this page helpful?" yes/no widget rendered at the
+ * bottom of every doc page. Set `feedback` to `false` to disable the
+ * widget site-wide.
+ */
+export interface FeedbackConfig {
+  /**
+   * Question shown to the reader.
+   *
+   * @default "Was this page helpful?"
+   */
+  readonly question?: string
+}
+
+/**
  * Edit-this-page link configuration (matches industry vocabulary —
  * VitePress / Nextra `editLink`).
  *
@@ -1619,6 +1635,12 @@ export interface CiderpressConfig {
    * the link entirely.
    */
   readonly reportLink?: false | ReportLinkConfig
+  /**
+   * "Was this page helpful?" feedback widget rendered under every doc page.
+   * Enabled by default. Set to `false` to disable site-wide, or pass an
+   * object to customise the question text.
+   */
+  readonly feedback?: false | FeedbackConfig
   /**
    * Home page configuration — hero, proof, features, showcase, split,
    * cta, and render order.

--- a/packages/ui/src/config.ts
+++ b/packages/ui/src/config.ts
@@ -957,8 +957,8 @@ function buildSiteBlock(params: {
     }))
 
   const feedbackBlock = match(params.feedback)
-    .with(false, () => ({ enabled: false, question: undefined }))
-    .with(undefined, () => ({ enabled: true, question: undefined }))
+    .with(true, () => ({ enabled: true, question: undefined }))
+    .with(P.union(false, undefined), () => ({ enabled: false, question: undefined }))
     .otherwise((f) => ({ enabled: true, question: f.question }))
 
   return {

--- a/packages/ui/src/config.ts
+++ b/packages/ui/src/config.ts
@@ -213,6 +213,7 @@ export function createRspressConfig(options: CreateRspressConfigOptions): UserCo
     config,
     editLink,
     reportLink,
+    feedback: config.feedback,
     topbar,
     sidebar,
     footer,
@@ -870,6 +871,10 @@ interface SiteBlock {
         readonly brandMark?: string
       }
     | undefined
+  readonly feedback: {
+    readonly enabled: boolean
+    readonly question: string | undefined
+  }
 }
 
 /**
@@ -887,6 +892,7 @@ function buildSiteBlock(params: {
   readonly config: CiderpressConfig
   readonly editLink: CiderpressConfig['editLink']
   readonly reportLink: CiderpressConfig['reportLink']
+  readonly feedback: CiderpressConfig['feedback']
   readonly topbar: CiderpressConfig['topbar']
   readonly sidebar: CiderpressConfig['sidebar']
   readonly footer: CiderpressConfig['footer']
@@ -950,6 +956,11 @@ function buildSiteBlock(params: {
       brandMark: f.brandMark,
     }))
 
+  const feedbackBlock = match(params.feedback)
+    .with(false, () => ({ enabled: false, question: undefined }))
+    .with(undefined, () => ({ enabled: true, question: undefined }))
+    .otherwise((f) => ({ enabled: true, question: f.question }))
+
   return {
     version: params.config.version,
     edit: editBlock,
@@ -958,6 +969,7 @@ function buildSiteBlock(params: {
     sidebarPromo,
     announcement,
     footer: footerBlock,
+    feedback: feedbackBlock,
   }
 }
 

--- a/packages/ui/src/theme/components/nav/layout.tsx
+++ b/packages/ui/src/theme/components/nav/layout.tsx
@@ -59,7 +59,14 @@ export function Layout(): React.ReactElement {
     .with(true, () => configNavItems)
     .otherwise(() => scrapedNavItems)
   const socialLinks = readSocialLinks(rspressSite)
-  const { announcement, topbarCta, sidebarPromo: sidebarPromoConfig, edit, report } = site ?? {}
+  const {
+    announcement,
+    topbarCta,
+    sidebarPromo: sidebarPromoConfig,
+    edit,
+    report,
+    feedback,
+  } = site ?? {}
   const { frontmatter } = useFrontmatter()
   const fmRecord = frontmatter as Record<string, unknown>
   const isHome = fmRecord.pageType === 'home'
@@ -113,9 +120,14 @@ export function Layout(): React.ReactElement {
 
   const metaActions = collectMetaActions({ edit, report, pagePath })
 
+  const feedbackSlot = match(feedback)
+    .with(undefined, () => <Feedback />)
+    .with({ enabled: false }, () => null)
+    .otherwise((f) => <Feedback question={f.question} />)
+
   const afterDocSlot = (
     <ContentFooterPortal>
-      <Feedback />
+      {feedbackSlot}
       <MetaActions actions={metaActions} />
     </ContentFooterPortal>
   )

--- a/packages/ui/src/theme/components/nav/layout.tsx
+++ b/packages/ui/src/theme/components/nav/layout.tsx
@@ -121,9 +121,8 @@ export function Layout(): React.ReactElement {
   const metaActions = collectMetaActions({ edit, report, pagePath })
 
   const feedbackSlot = match(feedback)
-    .with(undefined, () => <Feedback />)
-    .with({ enabled: false }, () => null)
-    .otherwise((f) => <Feedback question={f.question} />)
+    .with({ enabled: true }, (f) => <Feedback question={f.question} />)
+    .otherwise(() => null)
 
   const afterDocSlot = (
     <ContentFooterPortal>

--- a/packages/ui/src/theme/hooks/use-ciderpress.ts
+++ b/packages/ui/src/theme/hooks/use-ciderpress.ts
@@ -86,6 +86,10 @@ export interface CiderpressSiteBlock {
         readonly brandMark?: string
       }
     | undefined
+  readonly feedback: {
+    readonly enabled: boolean
+    readonly question: string | undefined
+  }
 }
 
 interface CiderpressThemeConfig {


### PR DESCRIPTION
## Summary

- Adds `feedback?: false | { question?: string }` to `CiderpressConfig`, mirroring the existing `editLink`/`reportLink` pattern.
- Widget is enabled by default (no behavior change for existing configs).
- `feedback: false` disables the widget site-wide; `feedback: { question: '...' }` renders a custom question.

## Changes

- **`packages/config/src/types.ts`** — new `FeedbackConfig` interface; `feedback` field on `CiderpressConfig`
- **`packages/config/src/schema.ts`** — new `feedbackConfigSchema` (exported); `feedback` wired into `ciderpressConfigSchema`; compile-time type guard added
- **`packages/config/src/index.ts`** — `FeedbackConfig` and `feedbackConfigSchema` exported
- **`packages/config/schemas/schema.json`** — auto-regenerated with `feedback` entry
- **`packages/ui/src/config.ts`** — `SiteBlock` gains `feedback: { enabled, question }` field; `buildSiteBlock` maps the three config states
- **`packages/ui/src/theme/hooks/use-ciderpress.ts`** — `CiderpressSiteBlock` gains matching `feedback` field
- **`packages/ui/src/theme/components/nav/layout.tsx`** — reads `feedback` from `site`; conditionally renders `<Feedback />` via `match()`, passing `question` through when present; `<MetaActions />` always renders
- **`docs/references/configuration.md`** — new `## feedback` section documenting all three states
- **`.changeset/feedback-config-toggle.md`** — minor changeset for `@ciderpress/config` and `@ciderpress/ui`

## Testing

- `pnpm check` (typecheck + lint + format) passes with 0 errors across all 16 tasks.
- The type guard `_guardFeedbackConfig: z.ZodType<FeedbackConfig> = feedbackConfigSchema` ensures the Zod schema and TS type stay in sync at compile time.

## Related

Closes the feedback widget toggle request. No existing configs are affected — omitting `feedback` preserves the current behavior.