### PR TITLE
feat(packages/cli): group the interactive draft template picker

### DIFF
--- a/.changeset/draft-grouped-picker.md
+++ b/.changeset/draft-grouped-picker.md
@@ -1,0 +1,11 @@
+---
+'@ciderpress/templates': minor
+'@ciderpress/cli': minor
+---
+
+Group the interactive `draft` template picker.
+
+Templates can now belong to a group, shown in the `draft` picker as a `Group/Name` label (e.g. `guides/UI`). A group comes from either a sub-directory under the configured templates dir (`.templates/guides/ui.md` → `guides`) or an explicit `group` frontmatter field, which wins over the directory. Templates at the templates root and all built-ins stay ungrouped and render flat.
+
+- **`@ciderpress/templates`** — `Template` gains an optional `group`; `buildTemplate` accepts a directory-derived `group` and reads a `group` frontmatter field (frontmatter overrides), with a new `invalid_group` validation error.
+- **`@ciderpress/cli`** — template discovery now recurses into sub-directories, tagging each template with its sub-path group; `draft` with no `type` shows the single grouped picker.

--- a/examples/simple/.templates/guides/ui.md
+++ b/examples/simple/.templates/guides/ui.md
@@ -1,0 +1,12 @@
+---
+label: UI Guide
+hint: Walkthrough for a UI feature
+---
+
+# {{title}}
+
+## Overview
+
+## Steps
+
+## Related

--- a/packages/cli/src/commands/draft.ts
+++ b/packages/cli/src/commands/draft.ts
@@ -3,22 +3,22 @@ import path from 'node:path'
 
 import { loadConfig } from '@ciderpress/config/loader'
 import { render, toSlug } from '@ciderpress/templates'
-import type { Template } from '@ciderpress/templates'
 import { command } from '@kidd-cli/core'
 import { match, P } from 'massaman/match'
 import { z } from 'zod'
 
 import { createPaths } from '../lib/paths.ts'
-import { configTemplates, resolveTemplates } from '../lib/templates.ts'
+import { configTemplates, resolveTemplates, toTemplateSelectOptions } from '../lib/templates.ts'
 
 /**
  * Scaffold a new documentation file from a template.
  *
- * Prompts for the doc type and title when not provided via args,
- * then writes the rendered template to the specified output directory.
- * Templates declared via the `templates` config field are merged with the
- * built-ins (user templates override built-ins by type); when no config or
- * `templates` field is present, only built-ins are offered.
+ * With a known `type` arg, scaffolds straight away. With no `type`, walks the
+ * user through an interactive picker — a single grouped list of built-in and
+ * config templates — then prompts for a title. Templates declared via the
+ * `templates` config field are merged with the built-ins (user templates
+ * override built-ins by type); when no config or `templates` field is present,
+ * only built-ins are offered.
  */
 export default command({
   name: 'draft',
@@ -33,7 +33,10 @@ export default command({
 
     const paths = createPaths(process.cwd())
     const [, config] = await loadConfig(paths.repoRoot)
-    const { registry } = await resolveTemplates({ templates: configTemplates(config), paths })
+    const { registry, resolved } = await resolveTemplates({
+      templates: configTemplates(config),
+      paths,
+    })
 
     const typeArg = ctx.args.type
     const hasValidType = match(typeArg)
@@ -45,11 +48,7 @@ export default command({
       .otherwise(() =>
         ctx.prompts.select<string>({
           message: 'Select a doc type',
-          options: registry.list().map((t: Template) => ({
-            value: t.type,
-            label: t.label,
-            hint: t.hint,
-          })),
+          options: [...toTemplateSelectOptions(resolved)],
         })
       )
 

--- a/packages/cli/src/lib/templates.test.ts
+++ b/packages/cli/src/lib/templates.test.ts
@@ -1,11 +1,11 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { createPaths } from './paths'
-import { resolveTemplates } from './templates'
+import { resolveTemplates, toTemplateSelectOptions } from './templates'
 
 // oxlint-disable-next-line functional/no-let -- per-test temp dir, reassigned in beforeEach
 let dir: string
@@ -26,6 +26,18 @@ afterEach(() => {
  */
 function write(name: string, body: string): void {
   writeFileSync(join(dir, name), body, 'utf8')
+}
+
+/**
+ * Write a template file into a sub-directory of the current temp dir.
+ *
+ * @param subdir - Sub-directory (relative to the temp dir), created if needed
+ * @param name - File name (with extension)
+ * @param body - Full file contents
+ */
+function writeIn(subdir: string, name: string, body: string): void {
+  mkdirSync(join(dir, subdir), { recursive: true })
+  writeFileSync(join(dir, subdir, name), body, 'utf8')
 }
 
 describe('resolveTemplates()', () => {
@@ -96,5 +108,56 @@ describe('resolveTemplates()', () => {
       paths: createPaths(dir),
     })
     expect(issues.some((issue) => issue.type === 'read_error')).toBe(true)
+  })
+
+  it('should discover templates nested in sub-directories and tag their group', async () => {
+    writeIn('guides', 'ui.md', '---\nlabel: UI\nhint: UI guide\n---\n# {{title}}\n')
+    const { registry, issues } = await resolveTemplates({
+      templates: [dir],
+      paths: createPaths(dir),
+    })
+    expect(issues).toStrictEqual([])
+    expect(registry.get('ui')).toMatchObject({ group: 'guides' })
+  })
+})
+
+describe('toTemplateSelectOptions()', () => {
+  it('should return flat, unprefixed labels when only built-ins exist', async () => {
+    const { resolved } = await resolveTemplates({ templates: undefined, paths: createPaths(dir) })
+    const options = toTemplateSelectOptions(resolved)
+    expect(options.length).toBeGreaterThan(0)
+    expect(options.some((option) => option.value === 'guide')).toBe(true)
+    expect(options.every((option) => !option.label.includes('/'))).toBe(true)
+  })
+
+  it('should carry each option as a value/label/hint row', async () => {
+    const { resolved } = await resolveTemplates({ templates: undefined, paths: createPaths(dir) })
+    const [option] = toTemplateSelectOptions(resolved)
+    expect(option).toMatchObject({
+      value: expect.any(String),
+      label: expect.any(String),
+      hint: expect.any(String),
+    })
+  })
+
+  it('should leave a root-level custom template unprefixed', async () => {
+    write('adr.md', '---\nlabel: ADR\nhint: Decision\n---\n# {{title}}\n')
+    const { resolved } = await resolveTemplates({ templates: [dir], paths: createPaths(dir) })
+    const options = toTemplateSelectOptions(resolved)
+    expect(options.find((option) => option.value === 'adr')).toMatchObject({ label: 'ADR' })
+  })
+
+  it('should prefix a sub-directory template with its folder group', async () => {
+    writeIn('guides', 'ui.md', '---\nlabel: UI\nhint: UI guide\n---\n# {{title}}\n')
+    const { resolved } = await resolveTemplates({ templates: [dir], paths: createPaths(dir) })
+    const options = toTemplateSelectOptions(resolved)
+    expect(options.find((option) => option.value === 'ui')).toMatchObject({ label: 'guides/UI' })
+  })
+
+  it('should let a frontmatter group override the directory-derived group', async () => {
+    writeIn('guides', 'api.md', '---\nlabel: API\nhint: API doc\ngroup: foobar\n---\n# {{title}}\n')
+    const { resolved } = await resolveTemplates({ templates: [dir], paths: createPaths(dir) })
+    const options = toTemplateSelectOptions(resolved)
+    expect(options.find((option) => option.value === 'api')).toMatchObject({ label: 'foobar/API' })
   })
 })

--- a/packages/cli/src/lib/templates.ts
+++ b/packages/cli/src/lib/templates.ts
@@ -93,6 +93,30 @@ export function configTemplates(
 }
 
 /**
+ * A selectable option for a single-select template prompt.
+ */
+export interface TemplateOption {
+  readonly value: string
+  readonly label: string
+  readonly hint: string
+}
+
+/**
+ * Build a flat option list for a single-select template prompt. Templates that
+ * declare a group — via a `group` frontmatter field or a sub-directory under
+ * the templates dir — render as `Group/Label` (e.g. `guides/UI`); ungrouped
+ * templates (files at the templates root and all built-ins) render flat.
+ *
+ * @param resolved - The resolved templates from {@link resolveTemplates}
+ * @returns The options in resolved order, prefixed only for grouped templates
+ */
+export function toTemplateSelectOptions(
+  resolved: readonly ResolvedTemplate[]
+): readonly TemplateOption[] {
+  return resolved.map((entry) => toOption(entry.template))
+}
+
+/**
  * A user template successfully loaded from a file.
  */
 interface LoadedTemplate {
@@ -153,7 +177,29 @@ async function loadDir(input: { readonly repoRoot: string; readonly dir: string 
   readonly issues: readonly TemplateIssue[]
 }> {
   const { repoRoot, dir } = input
-  const absDir = path.resolve(repoRoot, dir)
+  return walkTemplates({ absDir: path.resolve(repoRoot, dir), relDir: dir, group: undefined })
+}
+
+/**
+ * Recursively load supported template files under a directory, tagging each
+ * with the group derived from its location. Files at the configured root are
+ * ungrouped; each nested directory contributes a `parent/child` group segment.
+ * A frontmatter `group` overrides the derived value in {@link buildTemplate}.
+ *
+ * @private
+ * @param input - The current absolute + repo-relative dir and the accumulated
+ *   group for files at this level
+ * @returns Loaded templates and any per-file or directory-read issues
+ */
+async function walkTemplates(input: {
+  readonly absDir: string
+  readonly relDir: string
+  readonly group: string | undefined
+}): Promise<{
+  readonly loaded: readonly LoadedTemplate[]
+  readonly issues: readonly TemplateIssue[]
+}> {
+  const { absDir, relDir, group } = input
 
   const read = await attemptAsync(() => fs.readdir(absDir, { withFileTypes: true }))
   if (!read.ok) {
@@ -161,7 +207,7 @@ async function loadDir(input: { readonly repoRoot: string; readonly dir: string 
       loaded: [],
       issues: [
         {
-          file: dir,
+          file: relDir,
           type: 'read_error',
           message: `Cannot read templates directory: ${read.error.message}`,
         },
@@ -169,7 +215,9 @@ async function loadDir(input: { readonly repoRoot: string; readonly dir: string 
     }
   }
 
-  const candidates = read.value
+  const entries = read.value
+
+  const candidates = entries
     .filter((entry) => entry.isFile())
     .map((entry) => ({ name: entry.name, extension: toExtension(entry.name) }))
     .flatMap((candidate) => {
@@ -183,26 +231,60 @@ async function loadDir(input: { readonly repoRoot: string; readonly dir: string 
     candidates.map((candidate) =>
       loadTemplateFile({
         absPath: path.join(absDir, candidate.name),
-        relPath: path.join(dir, candidate.name),
+        relPath: path.join(relDir, candidate.name),
         extension: candidate.extension,
+        group,
       })
     )
   )
 
+  const subResults = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) =>
+        walkTemplates({
+          absDir: path.join(absDir, entry.name),
+          relDir: path.join(relDir, entry.name),
+          group: extendGroup(group, entry.name),
+        })
+      )
+  )
+
   return {
-    loaded: outcomes.flatMap((outcome) => {
-      if (outcome.kind === 'ok') {
-        return [outcome.loaded]
-      }
-      return []
-    }),
-    issues: outcomes.flatMap((outcome) => {
-      if (outcome.kind === 'issue') {
-        return [outcome.issue]
-      }
-      return []
-    }),
+    loaded: [
+      ...outcomes.flatMap((outcome) => {
+        if (outcome.kind === 'ok') {
+          return [outcome.loaded]
+        }
+        return []
+      }),
+      ...subResults.flatMap((result) => result.loaded),
+    ],
+    issues: [
+      ...outcomes.flatMap((outcome) => {
+        if (outcome.kind === 'issue') {
+          return [outcome.issue]
+        }
+        return []
+      }),
+      ...subResults.flatMap((result) => result.issues),
+    ],
   }
+}
+
+/**
+ * Extend a group path with a nested directory segment.
+ *
+ * @private
+ * @param group - The parent group, or undefined at the configured root
+ * @param name - The nested directory name
+ * @returns `name` at the root, otherwise `group/name`
+ */
+function extendGroup(group: string | undefined, name: string): string {
+  if (group === undefined) {
+    return name
+  }
+  return `${group}/${name}`
 }
 
 /**
@@ -216,8 +298,9 @@ async function loadTemplateFile(input: {
   readonly absPath: string
   readonly relPath: string
   readonly extension: '.md' | '.mdx'
+  readonly group: string | undefined
 }): Promise<FileOutcome> {
-  const { absPath, relPath, extension } = input
+  const { absPath, relPath, extension, group } = input
 
   const read = await attemptAsync(() => fs.readFile(absPath, 'utf8'))
   if (!read.ok) {
@@ -241,6 +324,7 @@ async function loadTemplateFile(input: {
     data: matter.data,
     content: matter.content,
     extension,
+    group,
   })
   if (buildError) {
     return {
@@ -314,4 +398,20 @@ function buildResolvedList(unique: readonly LoadedTemplate[]): readonly Resolved
   }))
 
   return [...builtInResolved, ...userResolved]
+}
+
+/**
+ * Map a template to a selectable prompt option, prefixing its label with the
+ * template's group when one is set.
+ *
+ * @private
+ * @param template - The template to project
+ * @returns The option with a `Group/Label` display label, or a flat label
+ */
+function toOption(template: Template): TemplateOption {
+  const { type, label, hint, group } = template
+  if (group === undefined || group.length === 0) {
+    return { value: type, label, hint }
+  }
+  return { value: type, label: `${group}/${label}`, hint }
 }

--- a/packages/templates/src/build.test.ts
+++ b/packages/templates/src/build.test.ts
@@ -74,4 +74,43 @@ describe('buildTemplate()', () => {
     expect(error).toMatchObject({ type: 'unknown_placeholder' })
     expect(template).toBeNull()
   })
+
+  it('should read a group from frontmatter', () => {
+    const [error, template] = buildTemplate({
+      ...validInput,
+      data: { label: 'ADR', hint: 'x', group: 'foobar' },
+    })
+    expect(error).toBeNull()
+    expect(template).toMatchObject({ group: 'foobar' })
+  })
+
+  it('should fall back to the directory group when frontmatter omits one', () => {
+    const [error, template] = buildTemplate({ ...validInput, group: 'guides' })
+    expect(error).toBeNull()
+    expect(template).toMatchObject({ group: 'guides' })
+  })
+
+  it('should let a frontmatter group override the directory group', () => {
+    const [error, template] = buildTemplate({
+      ...validInput,
+      data: { label: 'ADR', hint: 'x', group: 'frontmatter' },
+      group: 'directory',
+    })
+    expect(error).toBeNull()
+    expect(template).toMatchObject({ group: 'frontmatter' })
+  })
+
+  it('should reject an empty-string group', () => {
+    const [error, template] = buildTemplate({
+      ...validInput,
+      data: { label: 'ADR', hint: 'x', group: '   ' },
+    })
+    expect(error).toMatchObject({ type: 'invalid_group' })
+    expect(template).toBeNull()
+  })
+
+  it('should omit group when neither frontmatter nor directory sets one', () => {
+    const [, template] = buildTemplate(validInput)
+    expect(template).not.toHaveProperty('group')
+  })
 })

--- a/packages/templates/src/build.ts
+++ b/packages/templates/src/build.ts
@@ -4,7 +4,7 @@ import type { Result, Template, TemplateError, TemplateErrorType } from './types
 
 const TYPE_PATTERN = /^[a-z0-9-]+$/
 const PLACEHOLDER_PATTERN = /\{\{\s*([^}]+?)\s*\}\}/g
-const ALLOWED_FIELDS = new Set(['label', 'hint'])
+const ALLOWED_FIELDS = new Set(['label', 'hint', 'group'])
 const ALLOWED_PLACEHOLDERS = new Set(['title'])
 
 /**
@@ -16,6 +16,12 @@ export interface BuildTemplateInput {
   readonly data: Record<string, unknown>
   readonly content: string
   readonly extension: '.md' | '.mdx'
+  /**
+   * Group derived from the template's location (e.g. its sub-directory). Used
+   * when the frontmatter omits an explicit `group`; a frontmatter `group`
+   * always wins.
+   */
+  readonly group?: string
 }
 
 /**
@@ -56,7 +62,7 @@ export function buildTemplate(input: BuildTemplateInput): Result<Template, Templ
     return [
       templateError(
         'unknown_field',
-        `Unknown frontmatter field "${unknownField}" in template "${type}" (allowed: label, hint)`
+        `Unknown frontmatter field "${unknownField}" in template "${type}" (allowed: label, hint, group)`
       ),
       null,
     ]
@@ -72,6 +78,11 @@ export function buildTemplate(input: BuildTemplateInput): Result<Template, Templ
     return [hintError, null]
   }
 
+  const [groupError, frontmatterGroup] = readOptionalGroup({ type, value: data.group })
+  if (groupError) {
+    return [groupError, null]
+  }
+
   if (content.trim().length === 0) {
     return [templateError('empty_body', `Template "${type}" has an empty body`), null]
   }
@@ -81,7 +92,11 @@ export function buildTemplate(input: BuildTemplateInput): Result<Template, Templ
     return [placeholderError, null]
   }
 
-  return [null, { type, label, hint, body: content, extension }]
+  const group = frontmatterGroup ?? input.group
+  if (group === undefined) {
+    return [null, { type, label, hint, body: content, extension }]
+  }
+  return [null, { type, label, hint, body: content, extension, group }]
 }
 
 /**
@@ -121,6 +136,34 @@ function readStringField(input: {
       templateError(
         'missing_field',
         `Template "${type}" is missing required "${field}" (must be a non-empty string)`
+      ),
+      null,
+    ]
+  }
+  return [null, value.trim()]
+}
+
+/**
+ * Read the optional `group` frontmatter field: absent yields `undefined`, a
+ * non-empty string is trimmed, and any other value is rejected.
+ *
+ * @private
+ * @param input - The template type and the raw `group` value
+ * @returns A Result tuple: the trimmed group or `undefined`, or an `invalid_group` error
+ */
+function readOptionalGroup(input: {
+  readonly type: string
+  readonly value: unknown
+}): Result<string | undefined, TemplateError> {
+  const { type, value } = input
+  if (value === undefined) {
+    return [null, undefined]
+  }
+  if (!isString(value) || value.trim().length === 0) {
+    return [
+      templateError(
+        'invalid_group',
+        `Template "${type}" has an invalid "group" (must be a non-empty string when set)`
       ),
       null,
     ]

--- a/packages/templates/src/types.ts
+++ b/packages/templates/src/types.ts
@@ -48,6 +48,12 @@ export interface Template {
    * Defaults to `.md`; `.mdx` routes the drafted file through the MDX pipeline.
    */
   readonly extension?: '.md' | '.mdx'
+  /**
+   * Optional group used to cluster the template in interactive pickers. Set
+   * from a `group` frontmatter field or derived from the template's
+   * sub-directory; absent for ungrouped and built-in templates.
+   */
+  readonly group?: string
 }
 
 /**
@@ -59,6 +65,7 @@ export type TemplateErrorType =
   | 'invalid_type'
   | 'unknown_placeholder'
   | 'empty_body'
+  | 'invalid_group'
 
 /**
  * A template validation failure. Distinct from a frontmatter parse failure


### PR DESCRIPTION
## Summary

`ciderpress draft` with no `--type` now walks the user through a single grouped picker instead of an ungrouped list. Templates can belong to a group, shown as a `Group/Name` label (e.g. `guides/UI Guide`). A group is resolved as: **frontmatter `group:` → else the sub-directory under the templates dir → else none.** Built-in and root-level templates stay flat. Picking a template scaffolds one file and prompts for its title, as before.

## Changes

**`@ciderpress/templates`**
- `Template` gains an optional `group` field (omitted when unset).
- `buildTemplate` accepts a directory-derived `group` and reads a `group` frontmatter field; frontmatter wins over the directory.
- New `invalid_group` validation error for a present-but-blank `group`.

**`@ciderpress/cli`**
- Template discovery now recurses into sub-directories, tagging each template with its sub-path group.
- `draft` renders a single grouped `select` (`Group/Name` labels) when no `type` is passed; `--type` skips the picker.
- Added `examples/simple/.templates/guides/ui.md` to demo a grouped template.

## Testing

- `@ciderpress/templates`: `build.test.ts` — 14 pass (adds group-from-frontmatter, directory fallback, precedence, `invalid_group`, omit-when-unset).
- `@ciderpress/cli`: `templates.test.ts` — 13 pass (adds recursive discovery + group tagging, root-level-flat, sub-dir prefix, frontmatter override).
- Typecheck + lint + format clean on all changed files.
- Manual: `templates list` discovers the nested `ui` template; `draft --type ui` scaffolds correctly; grouped picker shows built-ins + `ADR` flat, then `guides/UI Guide`.

## Notes

- `type` is still the filename stem, so identically-named files in different group folders still collide (`duplicate_type`), same as today. Group-scoped types would be a separate change.

## Related Issues

_None._