### PR TITLE
fix(packages/ui): size sidebar bottom band to content so it no longer reserves dead space when the promo is disabled

### DIFF
--- a/.changeset/sidebar-bottom-band-size-to-content.md
+++ b/.changeset/sidebar-bottom-band-size-to-content.md
@@ -1,0 +1,19 @@
+---
+'@ciderpress/ui': patch
+---
+
+Size the sidebar bottom band to its content
+
+The sidebar bottom band (`.cp-sidebar-bottom`, which holds the promo card and
+below-links) grew to fill all remaining sidebar height (`flex: 1 0 auto`) and
+bottom-aligned its content (`justify-content: flex-end`). When the nav tree was
+short — or the promo was disabled, leaving only the below-links — the band
+stretched full-height and stranded its content at the very bottom of the
+sidebar, leaving a large block of dead space between the last nav item and the
+links/promo.
+
+The band now sizes to its content (`flex: 0 0 auto`, no bottom-align) so the
+promo and links sit directly beneath the last nav item. `position: sticky;
+bottom: 0` is kept, so when the nav tree overflows the viewport and the sidebar
+scrolls, the band still pins to the viewport bottom and stays visible — the
+sticky offset is simply inert on a short, non-scrolling nav.

--- a/packages/ui/src/theme/styles/overrides/rail.css
+++ b/packages/ui/src/theme/styles/overrides/rail.css
@@ -145,18 +145,22 @@ html .rp-doc-layout__sidebar > :first-child:not(.cp-sidebar-top) {
 }
 
 html .cp-sidebar-bottom {
-  /* Grow to fill the remaining sidebar space so the nav tree stacks
-     from the top and this band occupies everything below it. When the
-     nav tree is short, the band is tall and its content (promo +
-     below-links) sits at its bottom via `justify-content: flex-end`. */
-  flex: 1 0 auto;
+  /* Size to content and sit directly under the nav tree. `flex: 0 0 auto`
+     (no grow) is deliberate: growing to fill (`1 0 auto`) stretched the
+     band across all leftover sidebar height, and a short nav tree left a
+     tall empty band with its content (promo + below-links) stranded at the
+     bottom. With no grow the band is exactly as tall as its content and
+     the promo/links hug the last nav item. */
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
-  /* When the sidebar scrolls (nav tree taller than viewport), this band
-     stays glued to the viewport bottom so the promo is always visible.
-     `z-index: 3` so the band paints above the thin overlay scrollbar
-     thumb so it doesn't appear to "go through" the band region. */
+  /* When the nav tree overflows the viewport the sidebar scrolls; this
+     band stays glued to the viewport bottom (`sticky bottom: 0`) so the
+     promo/links remain visible while the tree scrolls behind them. With a
+     short (non-scrolling) nav tree the sticky offset is never engaged, so
+     the band simply flows under the last nav item. `z-index: 3` paints it
+     above the thin overlay scrollbar thumb so it doesn't appear to "go
+     through" the band region. */
   position: sticky;
   bottom: 0;
   z-index: 3;


### PR DESCRIPTION
## Summary

The left doc sidebar's bottom band (`.cp-sidebar-bottom` — the promo card + below-links) reserved a fixed block of vertical space and pinned its content to the very bottom of the sidebar. When the nav tree was short, or the promo was disabled leaving only the below-links, this left a large stretch of dead space between the last nav item and the links/promo. This resizes the band to its content so the links/promo sit directly under the nav, while preserving the "pin to viewport bottom" behavior when a long nav tree scrolls.

## Root cause

`.cp-sidebar-bottom` used `flex: 1 0 auto` (grow to fill all remaining sidebar height) + `justify-content: flex-end` (bottom-align its content) + `position: sticky; bottom: 0`. The `flex-grow` stretched the band to fill the whole leftover column and `flex-end` shoved the promo/links to the bottom edge. On a short nav tree (or with the promo disabled, links-only) this manifested as a big empty gap above the links — the band behaved as if it had a preset height. Measured on the dogfood site at 1440×900 with a short nav: the last nav item ended at y=297 but the band stretched to 603px tall and the links were pushed to y=836 — roughly **~539px of dead space**.

## Fix

In `packages/ui/src/theme/styles/overrides/rail.css`, `.cp-sidebar-bottom`:

- `flex: 1 0 auto` → `flex: 0 0 auto` (no grow — size to content)
- removed `justify-content: flex-end`
- kept `position: sticky; bottom: 0`

On a short, non-scrolling nav the sticky offset is inert, so the band flows directly under the last nav item. On a long nav tree that overflows the viewport, sticky still pins the band to the viewport bottom so the promo/links stay visible while the nav scrolls behind — the original "always visible" intent is preserved. The explanatory comment block above the rule was rewritten to describe the new behavior. CSS-only, one property flip + one removal.

## Testing

Verified in a real browser (chrome-devtools) on the dogfood docs site across four states, at 1440px:

- **(a) promo disabled, links only, short nav** (the reported bug): band went from 603px tall / links at y=836 (**~539px dead gap**) → band 77px / links at y=310, **13px** from the last nav item (just the band's top padding + border). Dead space gone.
- **(b) promo enabled, short nav**: band sizes to its 231px content; promo + links sit directly under the nav, no dead space.
- **(c) long/overflowing nav (sidebar scrolls)**: scrolled to bottom, the band's bottom edge sits at the viewport bottom — `sticky bottom: 0` still pins it. No regression on the long-nav case.
- **(d) neither promo nor links configured**: `.cp-sidebar-bottom` is not rendered at all (layout returns null) — confirmed, no empty band, no regression.

`pnpm check` (typecheck + lint + format) passes: 16/16 tasks, 0 errors.

## Related

Follow-up to the sidebar-layout investigation on this branch. Adds a `@ciderpress/ui` patch changeset.