### PR TITLE
fix(packages/cli): render depth-0 leaf pages as sidebar links, not groups

### DIFF
--- a/.changeset/fix-depth-0-leaf-sidebar-group.md
+++ b/.changeset/fix-depth-0-leaf-sidebar-group.md
@@ -1,0 +1,7 @@
+---
+'@ciderpress/cli': patch
+---
+
+Fix top-level (depth-0) leaf pages rendering as collapsible sidebar groups with a dead chevron.
+
+A `pages[]` entry that is a leaf (`include`/`content`, no `pages` children) placed at the top level was written to the root `_meta.json` as a `dir` item regardless of whether it had children, so Rspress rendered it as an empty expandable group. The root meta now gates the `dir`/`file` distinction on whether the entry has children — matching the treatment already applied to nested and root-promoted entries — so a depth-0 leaf renders as a plain link.

--- a/.changeset/fix-nav-base-doubling.md
+++ b/.changeset/fix-nav-base-doubling.md
@@ -1,0 +1,7 @@
+---
+'@ciderpress/ui': patch
+---
+
+Fix top-nav links doubling the mount prefix on subpath deploys.
+
+The theme's primary nav is built by scraping Rspress's rendered `.rp-nav-menu`, whose hrefs already carry the site `base`. Those already-based hrefs were passed straight to `<Link>`, so react-router's `basename` applied the prefix a second time — every mounted example site (`base: /examples/<slug>/`) produced `/examples/<slug>/examples/<slug>/…` links that 404'd on click and hard refresh. The scraped hrefs are now un-based with `removeBase` before routing, so `<Link>` re-applies the prefix exactly once. The root docs site (`base: /`) is unaffected — `removeBase` is a no-op there.

--- a/.changeset/reject-nested-path-top-level-leaf.md
+++ b/.changeset/reject-nested-path-top-level-leaf.md
@@ -1,0 +1,7 @@
+---
+'@ciderpress/config': patch
+---
+
+Reject top-level leaf pages with a nested path during config validation.
+
+A visible leaf page (no `pages`) placed directly in `config.pages` renders as a top-level sidebar link, which resolves to a file at the content root. A nested `path` (e.g. `/getting-started/introduction`) files the page a directory deep, so the generated root `_meta.json` entry pointed at a file that wasn't there — a silent dead link in the sidebar. Config validation now fails with an actionable message telling you to use a single-segment path or nest the page under a section with `pages`.

--- a/benchmarks/src/helpers/fixtures.ts
+++ b/benchmarks/src/helpers/fixtures.ts
@@ -112,7 +112,6 @@ export function generateFixture(options: GenerateFixtureOptions): GeneratedFixtu
       title: '${name.charAt(0).toUpperCase()}${name.slice(1)}',
       path: '/${name}',
       include: '${name}/**/*.md',
-      recursive: true,
     }`
     )
     .join(',\n')
@@ -123,7 +122,7 @@ export function generateFixture(options: GenerateFixtureOptions): GeneratedFixtu
 
 export default defineConfig({
   title: 'Benchmark Fixture',
-  sections: [
+  pages: [
 ${sectionConfigs}
   ],
 })

--- a/ciderpress.config.ts
+++ b/ciderpress.config.ts
@@ -33,7 +33,10 @@ export default defineConfig({
       { text: 'Home', href: '/', icon: 'pixelarticons:home' },
       { text: 'Changelog', href: '/changelog', icon: 'pixelarticons:notes' },
     ],
-    bottom: [{ text: 'Contributing', href: '/contributing', icon: 'pixelarticons:git-merge' }],
+    bottom: [
+      { text: 'Examples', href: '/examples', icon: 'pixelarticons:layout-grid' },
+      { text: 'Contributing', href: '/contributing', icon: 'pixelarticons:git-merge' },
+    ],
     promo: {
       title: 'Ship docs that stay in sync',
       body: 'Pull docs from your codebase and keep them green automatically.',
@@ -225,6 +228,9 @@ export default defineConfig({
       path: '/examples',
       include: 'docs/examples/index.mdx',
       icon: 'pixelarticons:layout-grid',
+      // Surfaced via the sidebar bottom links (next to Contributing), not as a
+      // top-level section in the main sidebar tree.
+      nav: { hidden: true },
     },
     {
       title: 'Getting Started',

--- a/ciderpress.config.ts
+++ b/ciderpress.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
       { text: 'Changelog', href: '/changelog', icon: 'pixelarticons:notes' },
     ],
     bottom: [
-      { text: 'Examples', href: '/examples', icon: 'pixelarticons:layout-grid' },
+      { text: 'Examples', href: '/examples', icon: 'pixelarticons:app-windows' },
       { text: 'Contributing', href: '/contributing', icon: 'pixelarticons:git-merge' },
     ],
     promo: {
@@ -227,7 +227,7 @@ export default defineConfig({
       title: 'Examples',
       path: '/examples',
       include: 'docs/examples/index.mdx',
-      icon: 'pixelarticons:layout-grid',
+      icon: 'pixelarticons:app-windows',
       // Surfaced via the sidebar bottom links (next to Contributing), not as a
       // top-level section in the main sidebar tree.
       nav: { hidden: true },

--- a/e2e/tests/examples/navigation.spec.ts
+++ b/e2e/tests/examples/navigation.spec.ts
@@ -44,5 +44,23 @@ for (const example of EXAMPLES) {
       url.pathname.startsWith(example.mountBase),
       `${example.slug} click escaped to ${url.pathname}`
     ).toBe(true)
+
+    // Guard against the mount prefix being applied twice
+    // (`/examples/<slug>/examples/<slug>/…`). The theme scrapes Rspress's
+    // already-based nav hrefs; if they aren't un-based before re-routing
+    // through `<Link>`, react-router's basename doubles the prefix and the
+    // page 404s. `startsWith` alone can't catch it (a doubled path still
+    // starts with the mount), so assert the prefix appears exactly once.
+    const doubledMount = `${example.mountBase}${example.mountBase.slice(1)}`
+    expect(
+      url.pathname.includes(doubledMount),
+      `${example.slug} doubled mount prefix: ${url.pathname}`
+    ).toBe(false)
+
+    // And the destination must actually resolve, not land on the SPA 404.
+    const heading = (await page.locator('h1').first().textContent()) ?? ''
+    expect(heading.toUpperCase(), `${example.slug} nav landed on 404`).not.toContain(
+      'PAGE NOT FOUND'
+    )
   })
 }

--- a/packages/cli/src/lib/sync/sidebar/meta.test.ts
+++ b/packages/cli/src/lib/sync/sidebar/meta.test.ts
@@ -111,7 +111,11 @@ describe('buildRootMeta()', () => {
         link: '/getting-started',
         items: [{ title: 'Intro', link: '/getting-started/intro' }],
       },
-      { title: 'Packages', link: '/packages', items: [] },
+      {
+        title: 'Packages',
+        link: '/packages',
+        items: [{ title: 'CLI', link: '/packages/cli' }],
+      },
     ]
 
     const result = buildRootMeta(entries)
@@ -119,6 +123,28 @@ describe('buildRootMeta()', () => {
     expect(result).toStrictEqual([
       { type: 'dir', name: 'getting-started', label: 'Getting Started' },
       { type: 'dir', name: 'packages', label: 'Packages' },
+    ])
+  })
+
+  it('should render a top-level leaf page as a file, not a group', () => {
+    const entries: readonly ResolvedEntry[] = [
+      {
+        title: 'Introduction',
+        link: '/platform',
+        page: { outputPath: 'platform.md', frontmatter: {} },
+      },
+      {
+        title: 'Concepts',
+        link: '/concepts',
+        items: [{ title: 'Overview', link: '/concepts/overview' }],
+      },
+    ]
+
+    const result = buildRootMeta(entries)
+
+    expect(result).toStrictEqual([
+      { type: 'file', name: 'platform', label: 'Introduction' },
+      { type: 'dir', name: 'concepts', label: 'Concepts' },
     ])
   })
 
@@ -136,7 +162,11 @@ describe('buildRootMeta()', () => {
 
   it('should promote root section children to top-level meta items', () => {
     const entries: readonly ResolvedEntry[] = [
-      { title: 'Getting Started', link: '/getting-started', items: [] },
+      {
+        title: 'Getting Started',
+        link: '/getting-started',
+        items: [{ title: 'Intro', link: '/getting-started/intro' }],
+      },
       referenceRoot,
     ]
 

--- a/packages/cli/src/lib/sync/sidebar/meta.ts
+++ b/packages/cli/src/lib/sync/sidebar/meta.ts
@@ -84,32 +84,39 @@ export function buildRootMeta(entries: readonly ResolvedEntry[]): readonly MetaI
     .filter((e) => !e.hidden)
     .flatMap((entry) => {
       if (entry.root && entry.items) {
-        return entry.items
-          .filter((child) => !child.hidden)
-          .flatMap((child): readonly (MetaDirItem | MetaFileItem)[] => {
-            const name = resolveDirName(child)
-            if (name === null) {
-              return []
-            }
-            if (hasChildren(child)) {
-              return [{ type: 'dir' as const, name, label: child.title }]
-            }
-            return [{ type: 'file' as const, name, label: child.title }]
-          })
+        return entry.items.filter((child) => !child.hidden).flatMap(entryToRootMetaItem)
       }
 
-      const name = resolveDirName(entry)
-      if (name === null) {
-        return []
-      }
-      return [
-        {
-          type: 'dir' as const,
-          name,
-          label: entry.title,
-        },
-      ]
+      return entryToRootMetaItem(entry)
     })
+}
+
+/**
+ * Convert a top-level entry to its root `_meta.json` item.
+ *
+ * Sections (entries with children) map to `dir` items so Rspress recurses
+ * into their subdirectory. Leaf pages (no children) map to `file` items so
+ * Rspress renders a plain link — without this gate a depth-0 leaf renders as
+ * a collapsible group with a dead chevron.
+ *
+ * @private
+ * @param entry - Top-level resolved entry (section or leaf)
+ * @returns Single-element meta item array, or empty when no name resolves
+ */
+function entryToRootMetaItem(entry: ResolvedEntry): readonly (MetaDirItem | MetaFileItem)[] {
+  if (hasChildren(entry)) {
+    const name = resolveDirName(entry)
+    if (name === null) {
+      return []
+    }
+    return [{ type: 'dir' as const, name, label: entry.title }]
+  }
+
+  const name = resolveFileStem(entry) ?? resolveDirName(entry)
+  if (name === null) {
+    return []
+  }
+  return [{ type: 'file' as const, name, label: entry.title }]
 }
 
 /**

--- a/packages/cli/src/lib/sync/sidebar/meta.ts
+++ b/packages/cli/src/lib/sync/sidebar/meta.ts
@@ -84,10 +84,10 @@ export function buildRootMeta(entries: readonly ResolvedEntry[]): readonly MetaI
     .filter((e) => !e.hidden)
     .flatMap((entry) => {
       if (entry.root && entry.items) {
-        return entry.items.filter((child) => !child.hidden).flatMap(entryToRootMetaItem)
+        return entry.items.filter((child) => !child.hidden).flatMap(entryToRootMetaItems)
       }
 
-      return entryToRootMetaItem(entry)
+      return entryToRootMetaItems(entry)
     })
 }
 
@@ -103,7 +103,7 @@ export function buildRootMeta(entries: readonly ResolvedEntry[]): readonly MetaI
  * @param entry - Top-level resolved entry (section or leaf)
  * @returns Single-element meta item array, or empty when no name resolves
  */
-function entryToRootMetaItem(entry: ResolvedEntry): readonly (MetaDirItem | MetaFileItem)[] {
+function entryToRootMetaItems(entry: ResolvedEntry): readonly (MetaDirItem | MetaFileItem)[] {
   if (hasChildren(entry)) {
     const name = resolveDirName(entry)
     if (name === null) {

--- a/packages/config/src/validator.test.ts
+++ b/packages/config/src/validator.test.ts
@@ -38,6 +38,55 @@ describe('validateConfig()', () => {
   })
 })
 
+describe('validateConfig() — top-level page placement', () => {
+  it('should reject a top-level leaf page with a nested path', () => {
+    const [error, config] = validateConfig({
+      pages: [{ title: 'Introduction', path: '/getting-started/introduction', content: '# Intro' }],
+    })
+    expect(config).toBeNull()
+    expect(error).toMatchObject({
+      type: 'invalid_section',
+      message: expect.stringContaining("nested path '/getting-started/introduction'"),
+    })
+  })
+
+  it('should accept a top-level leaf page with a single-segment path', () => {
+    const [error] = validateConfig({
+      pages: [{ title: 'Examples', path: '/examples', content: '# Examples' }],
+    })
+    expect(error).toBeNull()
+  })
+
+  it('should accept a nested leaf page with a nested path', () => {
+    const [error] = validateConfig({
+      pages: [
+        {
+          title: 'Getting Started',
+          path: '/getting-started',
+          pages: [
+            { title: 'Introduction', path: '/getting-started/introduction', content: '# Intro' },
+          ],
+        },
+      ],
+    })
+    expect(error).toBeNull()
+  })
+
+  it('should not flag a hidden top-level leaf with a nested path', () => {
+    const [error] = validateConfig({
+      pages: [
+        {
+          title: 'Changelog',
+          path: '/meta/changelog',
+          content: '# Changelog',
+          nav: { hidden: true },
+        },
+      ],
+    })
+    expect(error).toBeNull()
+  })
+})
+
 describe('defineConfig()', () => {
   it('should return the same config object passed in', () => {
     const config = defineConfig(validConfig)

--- a/packages/config/src/validator.ts
+++ b/packages/config/src/validator.ts
@@ -94,6 +94,11 @@ function validateSemantics(config: CiderpressConfig): ConfigResult<true> {
     return [pageErrors, null]
   }
 
+  const [placementErr] = validateTopLevelPlacement(config.pages)
+  if (placementErr) {
+    return [placementErr, null]
+  }
+
   const featureItems = readFeatureItems(config)
   const [featErr] = validateFeatures(featureItems)
   if (featErr) {
@@ -355,6 +360,77 @@ function validatePage(page: Page): ConfigResult<true> {
   }
 
   return [null, true]
+}
+
+/**
+ * Validate placement of direct top-level pages.
+ *
+ * A visible leaf page (no `pages`) placed directly in `config.pages` becomes a
+ * top-level sidebar entry, which resolves to a file at the content root. A
+ * nested `path` (e.g. `/guides/intro`) files the page a directory deep, so the
+ * root `_meta.json` entry points at a file that isn't there — a silent dead
+ * link. Reject it with an actionable message rather than shipping a broken
+ * sidebar. Only direct children of `config.pages` are checked; nested leaves
+ * are expected to carry deeper paths.
+ *
+ * @private
+ * @param pages - Top-level page entries from `config.pages`
+ * @returns First placement error encountered, or success
+ */
+function validateTopLevelPlacement(pages: readonly Page[]): ConfigResult<true> {
+  const offending = pages.find(isMisplacedTopLevelLeaf)
+  if (offending) {
+    const titleStr = stringifyTitle(offending.title)
+    const offendingPath = offending.path as string
+    return [
+      configError(
+        'invalid_section',
+        `Page "${titleStr}": a top-level page with the nested path '${offendingPath}' can't render as a top-level sidebar link. Use a single-segment path (e.g. '/${pathSegments(offendingPath).at(-1)}') or nest it under a section with 'pages'.`
+      ),
+      null,
+    ]
+  }
+  return [null, true]
+}
+
+/**
+ * Determine whether a top-level page is a visible leaf whose nested path would
+ * produce a dead top-level sidebar link.
+ *
+ * Sections (`pages`), OpenAPI mounts, and pages excluded from the main sidebar
+ * (`nav.hidden` / `nav.island`) never emit a root file item, so they are exempt.
+ *
+ * @private
+ * @param page - Top-level page entry
+ * @returns True when the page is a misplaced top-level leaf
+ */
+function isMisplacedTopLevelLeaf(page: Page): boolean {
+  if (page.pages || page.openapi) {
+    return false
+  }
+  const nav = page.nav
+  const excludedFromMainSidebar = match(nav)
+    .with(P.nonNullable, (n) => n.hidden === true || n.island === true)
+    .otherwise(() => false)
+  if (excludedFromMainSidebar) {
+    return false
+  }
+  const offendingPath = page.path
+  if (!offendingPath) {
+    return false
+  }
+  return pathSegments(offendingPath).length > 1
+}
+
+/**
+ * Split a URL path into its non-empty segments.
+ *
+ * @private
+ * @param path - URL path (e.g. `/guides/intro`)
+ * @returns Non-empty path segments (e.g. `['guides', 'intro']`)
+ */
+function pathSegments(path: string): readonly string[] {
+  return path.split('/').filter(Boolean)
 }
 
 /**

--- a/packages/ui/src/theme/components/nav/ciderpress-nav-menu.tsx
+++ b/packages/ui/src/theme/components/nav/ciderpress-nav-menu.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from '@rspress/core/runtime'
+import { removeBase, useLocation } from '@rspress/core/runtime'
 import { clsx } from 'clsx'
 import { match } from 'massaman/match'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -287,7 +287,11 @@ function scrapeNavItems(): readonly CiderpressNavMenuItem[] {
   return [...anchors]
     .map((anchor) => ({
       text: readAnchorText(anchor),
-      link: anchor.getAttribute('href') ?? '',
+      // Rspress's rendered `.rp-nav-menu` hrefs already carry the site `base`.
+      // Strip it here so `RouteLink` (→ Rspress `<Link>`) can re-apply it once
+      // rather than doubling the mount prefix on a subpath deploy (the
+      // `/examples/<slug>/examples/<slug>/…` 404 on mounted example sites).
+      link: removeBase(anchor.getAttribute('href') ?? ''),
     }))
     .filter((item) => item.text !== '' && item.link !== '')
 }

--- a/packages/ui/src/theme/hooks/use-nav-items.ts
+++ b/packages/ui/src/theme/hooks/use-nav-items.ts
@@ -1,3 +1,4 @@
+import { removeBase } from '@rspress/core/runtime'
 import { useEffect, useState } from 'react'
 
 import type { CiderpressNavMenuItem } from '../components/nav/ciderpress-nav-menu'
@@ -53,7 +54,10 @@ function scrapeNavItems(): readonly CiderpressNavMenuItem[] {
   return [...anchors]
     .map((anchor) => ({
       text: readAnchorText(anchor),
-      link: anchor.getAttribute('href') ?? '',
+      // Rspress's rendered hrefs already include the site `base`; strip it so
+      // the consuming `<Link>` re-applies it once instead of doubling the mount
+      // prefix on subpath deploys (the `/examples/<slug>/examples/<slug>/…` 404).
+      link: removeBase(anchor.getAttribute('href') ?? ''),
     }))
     .filter((item) => item.text !== '' && item.link !== '')
 }


### PR DESCRIPTION
## Summary

Started as the #142 sidebar fix; grew to cover the related depth/base bugs that surfaced while validating on the live examples. All changes are in the sidebar/nav/base area or its guards.

## Changes

**Sidebar (#142)**
- `@ciderpress/cli` — depth-0 leaf pages now render as plain sidebar links, not collapsible groups with a dead chevron. `buildRootMeta` gates `dir` vs `file` on `hasChildren` (shared `entryToRootMetaItems`), matching the root-promoted branch.

**Config validation (framework footgun)**
- `@ciderpress/config` — reject a visible top-level leaf with a nested `path` (e.g. `/getting-started/introduction` placed directly in `pages[]`). Such a page can never be a top-level sidebar link — its file lands a directory deep, so the root `_meta.json` entry pointed at a missing file (a silent dead link). Now fails validation with an actionable message.

**Example sites — base doubling (the "none of the examples work" bug)**
- `@ciderpress/ui` — the primary nav is built by scraping Rspress's rendered `.rp-nav-menu`, whose hrefs already include the site `base`. Passing them straight to `<Link>` let react-router's basename apply the prefix twice, so every mounted example (`base: /examples/<slug>/`) produced `/examples/<slug>/examples/<slug>/…` links that 404'd on click and hard refresh. Un-base the scraped hrefs with `removeBase` in all scrape paths (leaf + dropdown, in both the `useNavItems` hook and the nav-menu component). No-op on the root site (`base: /`).
- Tightened the examples navigation e2e: assert the mount prefix appears exactly once and the click doesn't land on the SPA 404 — closing the `startsWith`-only blind spot that let this ship.

**Docs / housekeeping**
- Relocate the docs `Examples` page out of the main sidebar into the bottom links next to `Contributing` (`nav.hidden` + `sidebar.bottom`), with the `pixelarticons:app-windows` icon.
- `benchmarks` — fix the fixture config to the current schema (`pages` not `sections`; drop the invalid top-level `recursive`) so the bench suite loads again.

## Testing

- `pnpm check` clean; unit tests green (config 48, cli 210, ui 51, theme 38, templates 49).
- Base-doubling fix reproduced and verified with Playwright against the merged build (leaf + dropdown nav, click + hard refresh); root docs site unaffected.
- CI `e2e` green — builds all four example sites and exercises the new doubling guard.

## Related Issues

Closes #142