### PR TITLE
feat(packages/ui): render topbar nav dropdowns on desktop and mobile

### DIFF
--- a/.changeset/topbar-nav-dropdowns.md
+++ b/.changeset/topbar-nav-dropdowns.md
@@ -1,0 +1,9 @@
+---
+'@ciderpress/ui': minor
+---
+
+Render topbar nav dropdowns. Nav items with an `items` array now paint as
+submenus instead of being dropped: on desktop as a hover/click popover (with a
+hover bridge and close delay so it doesn't snap shut), and on mobile as a
+collapsible accordion in the drawer. `CiderpressNavMenuItem.link` is now
+optional and `items` is supported, matching the config-side `NavItem` shape.

--- a/examples/simple/ciderpress.config.ts
+++ b/examples/simple/ciderpress.config.ts
@@ -33,9 +33,14 @@ export default defineConfig({
   ],
   topbar: {
     nav: [
-      { title: 'Docs', link: '/getting-started' },
-      { title: 'API', link: '/api-reference' },
-      { title: 'Guides', link: '/guides' },
+      { title: 'Getting Started', link: '/getting-started' },
+      {
+        title: 'Reference',
+        items: [
+          { title: 'API Reference', link: '/api-reference' },
+          { title: 'Guides', link: '/guides' },
+        ],
+      },
     ],
   },
   footer: {

--- a/packages/ui/src/theme/components/nav/ciderpress-nav-hamburger.css
+++ b/packages/ui/src/theme/components/nav/ciderpress-nav-hamburger.css
@@ -141,6 +141,56 @@
   text-decoration: none;
 }
 
+.cp-nav-drawer__group {
+  display: flex;
+  flex-direction: column;
+}
+
+.cp-nav-drawer__group-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: var(--cp-c-text-1);
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    color 0.12s ease;
+}
+
+.cp-nav-drawer__group-toggle:hover {
+  background: var(--cp-c-bg-soft);
+  color: var(--cp-c-brand-1);
+}
+
+.cp-nav-drawer__group-chevron {
+  flex-shrink: 0;
+  color: var(--cp-c-text-2);
+  transition: transform 0.18s ease;
+}
+
+.cp-nav-drawer__group-toggle[aria-expanded='true'] .cp-nav-drawer__group-chevron {
+  transform: rotate(180deg);
+}
+
+.cp-nav-drawer__group-items {
+  display: flex;
+  flex-direction: column;
+}
+
+.cp-nav-drawer__link--nested {
+  padding-left: 28px;
+  font-size: 14px;
+}
+
 .cp-nav-drawer__divider {
   height: 1px;
   margin: 4px 20px;

--- a/packages/ui/src/theme/components/nav/ciderpress-nav-hamburger.tsx
+++ b/packages/ui/src/theme/components/nav/ciderpress-nav-hamburger.tsx
@@ -1,3 +1,4 @@
+import { match } from 'massaman/match'
 import { useState } from 'react'
 import type React from 'react'
 import { Dialog, Modal, ModalOverlay } from 'react-aria-components'
@@ -71,15 +72,12 @@ export function CiderpressNavHamburger(props: CiderpressNavHamburgerProps): Reac
             </header>
 
             <nav className="cp-nav-drawer__nav" aria-label="Primary">
-              {props.navItems.map((item) => (
-                <RouteLink
-                  key={item.link}
-                  href={item.link}
-                  className="cp-nav-drawer__link"
-                  onClick={() => setOpen(false)}
-                >
-                  {item.text}
-                </RouteLink>
+              {props.navItems.map((item, index) => (
+                <DrawerNavEntry
+                  key={`${drawerItemKey(item)}::${index}`}
+                  item={item}
+                  onNavigate={() => setOpen(false)}
+                />
               ))}
             </nav>
 
@@ -110,3 +108,91 @@ export function CiderpressNavHamburger(props: CiderpressNavHamburgerProps): Reac
 }
 
 export { CiderpressNavHamburger as default }
+
+/**
+ * Render one entry in the mobile drawer nav. Leaf items are a single
+ * link; dropdown parents become a collapsible {@link DrawerNavGroup}.
+ *
+ * @private
+ * @param props - The nav item and a callback to close the drawer.
+ * @returns The drawer entry element.
+ */
+function DrawerNavEntry(props: {
+  readonly item: CiderpressNavMenuItem
+  readonly onNavigate: () => void
+}): React.ReactElement {
+  const { item, onNavigate } = props
+  const children = item.items ?? []
+  return match(children.length > 0)
+    .with(true, () => <DrawerNavGroup item={item} onNavigate={onNavigate} />)
+    .otherwise(() => (
+      <RouteLink href={item.link ?? '#'} className="cp-nav-drawer__link" onClick={onNavigate}>
+        {item.text}
+      </RouteLink>
+    ))
+}
+
+/**
+ * A collapsible dropdown section in the mobile drawer: a tappable header
+ * that toggles its child links open/closed. Collapsed by default so a
+ * deep nav doesn't fill the drawer on open.
+ *
+ * @private
+ * @param props - The dropdown item and a callback to close the drawer.
+ * @returns The collapsible group element.
+ */
+function DrawerNavGroup(props: {
+  readonly item: CiderpressNavMenuItem
+  readonly onNavigate: () => void
+}): React.ReactElement {
+  const { item, onNavigate } = props
+  const [expanded, setExpanded] = useState(false)
+  const children = item.items ?? []
+  return (
+    <div className="cp-nav-drawer__group" role="group" aria-label={item.text}>
+      <button
+        type="button"
+        className="cp-nav-drawer__group-toggle"
+        onClick={() => setExpanded((current) => !current)}
+        aria-expanded={expanded}
+      >
+        <span>{item.text}</span>
+        <Icon
+          className="cp-nav-drawer__group-chevron"
+          icon="pixelarticons:chevron-down"
+          width={16}
+          height={16}
+        />
+      </button>
+      {expanded && (
+        <div className="cp-nav-drawer__group-items">
+          {children.map((child, index) => (
+            <RouteLink
+              key={`${drawerItemKey(child)}::${index}`}
+              href={child.link ?? '#'}
+              className="cp-nav-drawer__link cp-nav-drawer__link--nested"
+              onClick={onNavigate}
+            >
+              {child.text}
+            </RouteLink>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Stable React key for a drawer nav item — its link when present,
+ * otherwise its label (dropdown parents may have no link of their own).
+ *
+ * @private
+ * @param item - Nav item to key.
+ * @returns Key string.
+ */
+function drawerItemKey(item: CiderpressNavMenuItem): string {
+  if (item.link !== undefined && item.link !== '') {
+    return item.link
+  }
+  return item.text
+}

--- a/packages/ui/src/theme/components/nav/ciderpress-nav-menu.css
+++ b/packages/ui/src/theme/components/nav/ciderpress-nav-menu.css
@@ -50,6 +50,13 @@
   color: var(--cp-nav-menu-item-color-active, var(--cp-c-brand-1, currentColor));
 }
 
+/* Measurement-only: dropdown items render a label→chevron gap in the
+   live toggle, so the hidden measure span must include it to size
+   correctly. Applied only in the measure row. */
+.cp-nav-menu__item--measured-dropdown {
+  gap: 4px;
+}
+
 /* ── Hidden measurement layer ──────────────────────────────────────────
    Renders every item at full natural width so the JS layer always has
    a stable per-item measurement no matter how narrow the live menu
@@ -127,4 +134,85 @@
 
 .cp-nav-menu__overflow-item--active {
   color: var(--cp-nav-menu-item-color-active, var(--cp-c-brand-1, currentColor));
+}
+
+/* ── Inline dropdown (nav item with children) ──────────────────────── */
+.cp-nav-menu__dropdown {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.cp-nav-menu__dropdown-toggle {
+  gap: 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.cp-nav-menu__dropdown-popover {
+  position: absolute;
+  /* Sit below the toggle with breathing room. The visual gap is bridged
+     by the transparent `::before` band below, so the whole toggle→menu
+     path stays inside the hover region and moving toward the menu never
+     crosses empty space that would trigger a close. */
+  top: calc(100% + 12px);
+  /* Anchor to the toggle's right edge. The primary nav is right-aligned
+     in the topbar, so opening leftward keeps the popover on-screen
+     instead of overflowing the viewport's right edge. */
+  right: 0;
+  z-index: 60;
+  min-width: 200px;
+  margin: 0;
+  padding: 6px;
+  list-style: none;
+  background: var(--cp-nav-menu-overflow-bg, var(--cp-c-bg, #1e1e2e));
+  border: 1px solid var(--cp-nav-menu-overflow-border, var(--cp-c-border, #313244));
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+}
+
+/* Invisible bridge: a transparent band spanning the visual gap between
+   the toggle and the popover surface (and a little to each side), so the
+   pointer stays within the dropdown's hover region the whole way down.
+   Without it, the 6px gap is dead space and mouse-leave fires mid-move. */
+.cp-nav-menu__dropdown-popover::before {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: -12px;
+  right: -12px;
+  /* Taller than the 12px offset so the band overlaps both the toggle and
+     the popover surface — no hairline seam for the pointer to slip through. */
+  height: 16px;
+}
+
+/* ── Dropdown parents collapsed into the "More" popover ────────────── */
+.cp-nav-menu__overflow-group {
+  padding: 4px 0;
+}
+
+.cp-nav-menu__overflow-group + .cp-nav-menu__overflow-group,
+.cp-nav-menu__overflow-item + .cp-nav-menu__overflow-group {
+  margin-top: 4px;
+  border-top: 1px solid var(--cp-nav-menu-overflow-border, var(--cp-c-border, #313244));
+}
+
+.cp-nav-menu__overflow-group-label {
+  display: block;
+  padding: 6px 12px 2px;
+  /* text-2 (not text-3): these small uppercase labels need AA contrast,
+     and text-3's low alpha fails 4.5:1 on the light themes. */
+  color: var(--cp-c-text-2, #9399b2);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.cp-nav-menu__overflow-sublist {
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }

--- a/packages/ui/src/theme/components/nav/ciderpress-nav-menu.tsx
+++ b/packages/ui/src/theme/components/nav/ciderpress-nav-menu.tsx
@@ -23,12 +23,25 @@ const OVERFLOW_TOGGLE_WIDTH = 96
 const DEFAULT_GAP_PX = 16
 
 /**
+ * Grace period before a hover-opened dropdown closes on mouse-leave.
+ * Long enough to cross the gap into the popover without it snapping
+ * shut, short enough not to feel sticky.
+ */
+const CLOSE_DELAY_MS = 220
+
+/**
  * Single primary-nav entry — matches the shape of `site.nav[*]` in
  * `ciderpress.config.ts`.
+ *
+ * An entry is either a leaf (has `link`, no `items`) or a dropdown
+ * parent (has `items`, `link` optional). When a parent has children,
+ * its own `link` is ignored — the label toggles the submenu rather
+ * than navigating.
  */
 export interface CiderpressNavMenuItem {
   readonly text: string
-  readonly link: string
+  readonly link?: string
+  readonly items?: readonly CiderpressNavMenuItem[]
 }
 
 /**
@@ -151,24 +164,25 @@ export function CiderpressNavMenu(props: CiderpressNavMenuProps): React.ReactEle
   return (
     <>
       <div ref={measureRef} className="cp-nav-menu-measure" aria-hidden="true">
-        {items.map((item) => (
-          <span key={item.link} data-cp-menu-item className="cp-nav-menu__item">
+        {items.map((item, index) => (
+          <span
+            key={`${itemKey(item)}::${index}`}
+            data-cp-menu-item
+            className={clsx('cp-nav-menu__item', {
+              // Mirror the live dropdown toggle's label→chevron gap so the
+              // measured width matches what actually renders inline.
+              'cp-nav-menu__item--measured-dropdown': hasChildren(item),
+            })}
+          >
             {item.text}
+            {hasChildren(item) && <Icon icon="pixelarticons:chevron-down" width={12} height={12} />}
           </span>
         ))}
       </div>
 
       <nav ref={containerRef} className="cp-nav-menu" aria-label="Primary">
-        {visible.map((item) => (
-          <RouteLink
-            key={item.link}
-            href={item.link}
-            className={clsx('cp-nav-menu__item', {
-              'cp-nav-menu__item--active': isActive(pathname, item.link),
-            })}
-          >
-            {item.text}
-          </RouteLink>
+        {visible.map((item, index) => (
+          <NavMenuEntry key={`${itemKey(item)}::${index}`} item={item} pathname={pathname} />
         ))}
         {hasOverflow && (
           <div ref={overflowRef} className="cp-nav-menu__overflow">
@@ -184,19 +198,13 @@ export function CiderpressNavMenu(props: CiderpressNavMenuProps): React.ReactEle
             </button>
             {overflowOpen && (
               <ul className="cp-nav-menu__overflow-popover" role="menu">
-                {overflow.map((item) => (
-                  <li key={item.link} role="none">
-                    <RouteLink
-                      href={item.link}
-                      role="menuitem"
-                      className={clsx('cp-nav-menu__overflow-item', {
-                        'cp-nav-menu__overflow-item--active': isActive(pathname, item.link),
-                      })}
-                      onClick={() => setOverflowOpen(false)}
-                    >
-                      {item.text}
-                    </RouteLink>
-                  </li>
+                {overflow.map((item, index) => (
+                  <OverflowEntry
+                    key={`${itemKey(item)}::${index}`}
+                    item={item}
+                    pathname={pathname}
+                    onNavigate={() => setOverflowOpen(false)}
+                  />
                 ))}
               </ul>
             )}
@@ -208,6 +216,286 @@ export function CiderpressNavMenu(props: CiderpressNavMenuProps): React.ReactEle
 }
 
 export { CiderpressNavMenu as default }
+
+/**
+ * Render a single inline nav entry — a plain link when the item is a
+ * leaf, or a hover/click dropdown when it carries child `items`.
+ *
+ * @private
+ * @param props - The nav item and the current pathname.
+ * @returns The entry element.
+ */
+function NavMenuEntry(props: {
+  readonly item: CiderpressNavMenuItem
+  readonly pathname: string
+}): React.ReactElement {
+  const { item, pathname } = props
+  return match(hasChildren(item))
+    .with(true, () => <NavMenuDropdown item={item} pathname={pathname} />)
+    .otherwise(() => (
+      <RouteLink
+        href={item.link ?? '#'}
+        className={clsx('cp-nav-menu__item', {
+          'cp-nav-menu__item--active': isActiveLink(pathname, item.link),
+        })}
+      >
+        {item.text}
+      </RouteLink>
+    ))
+}
+
+/**
+ * A topbar dropdown: a toggle button plus a popover of child links.
+ * Opens on hover and on click, closes on outside click, on child
+ * navigation, or on `Escape`. The toggle is marked active when the
+ * current route matches any child link.
+ *
+ * @private
+ * @param props - The dropdown item and the current pathname.
+ * @returns The dropdown element.
+ */
+function NavMenuDropdown(props: {
+  readonly item: CiderpressNavMenuItem
+  readonly pathname: string
+}): React.ReactElement {
+  const { item, pathname } = props
+  // Two independent inputs: `hovering` (pointer preview) and `pinned`
+  // (an explicit click/tap/Enter latch). The menu is open when either is
+  // set. This keeps hover-to-preview and click-to-toggle from fighting —
+  // clicking an already-hover-open menu pins it instead of closing it.
+  const [hovering, setHovering] = useState(false)
+  const [pinned, setPinned] = useState(false)
+  const open = hovering || pinned
+  const ref = useRef<HTMLDivElement>(null)
+  const toggleRef = useRef<HTMLButtonElement>(null)
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const children = item.items ?? []
+
+  // Cancel any pending hover-close (mouse re-entered, or an explicit action).
+  function cancelClose(): void {
+    if (closeTimer.current !== null) {
+      clearTimeout(closeTimer.current)
+      closeTimer.current = null
+    }
+  }
+
+  // Fully close: drop both hover and pin. Used by Escape, outside-click,
+  // and child navigation.
+  function close(): void {
+    cancelClose()
+    setHovering(false)
+    setPinned(false)
+  }
+
+  // Drop the hover preview after a short grace period so brief excursions
+  // off the toggle (crossing into the popover, a jittery pointer) don't
+  // snap it shut. A pinned menu stays open regardless.
+  function scheduleClose(): void {
+    cancelClose()
+    closeTimer.current = setTimeout(() => setHovering(false), CLOSE_DELAY_MS)
+  }
+
+  useEffect(() => () => cancelClose(), [])
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    function onDocClick(event: MouseEvent): void {
+      const target = event.target as Node | null
+      if (target !== null && ref.current !== null && !ref.current.contains(target)) {
+        close()
+      }
+    }
+    function onKeyDown(event: KeyboardEvent): void {
+      if (event.key === 'Escape') {
+        close()
+        // Return focus to the toggle so a keyboard user isn't stranded
+        // on a link that just unmounted.
+        if (toggleRef.current !== null) {
+          toggleRef.current.focus()
+        }
+      }
+    }
+    document.addEventListener('mousedown', onDocClick)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onDocClick)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  const active = children.some((child) => isActiveLink(pathname, child.link))
+
+  function handleMouseEnter(): void {
+    cancelClose()
+    setHovering(true)
+  }
+
+  // Close when focus leaves the dropdown entirely (Tab past the last
+  // link). Keep it open while focus moves between the toggle and items.
+  function handleBlur(event: React.FocusEvent<HTMLDivElement>): void {
+    const next = event.relatedTarget
+    if (ref.current !== null && next instanceof Node && ref.current.contains(next)) {
+      return
+    }
+    close()
+  }
+
+  // Click/tap/Enter is an explicit latch: pin it open, or unpin (and drop
+  // any lingering hover) to close. Works identically for mouse, touch,
+  // and keyboard.
+  function handleToggleClick(): void {
+    cancelClose()
+    if (pinned) {
+      setPinned(false)
+      setHovering(false)
+      return
+    }
+    setPinned(true)
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="cp-nav-menu__dropdown"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={scheduleClose}
+      onBlur={handleBlur}
+    >
+      <button
+        ref={toggleRef}
+        type="button"
+        className={clsx('cp-nav-menu__item', 'cp-nav-menu__dropdown-toggle', {
+          'cp-nav-menu__item--active': active,
+        })}
+        onClick={handleToggleClick}
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <span>{item.text}</span>
+        <Icon icon="pixelarticons:chevron-down" width={12} height={12} />
+      </button>
+      {open && (
+        <ul className="cp-nav-menu__dropdown-popover" role="menu" aria-label={item.text}>
+          {children.map((child, index) => (
+            <li key={`${itemKey(child)}::${index}`} role="none">
+              <RouteLink
+                href={child.link ?? '#'}
+                role="menuitem"
+                className={clsx('cp-nav-menu__overflow-item', {
+                  'cp-nav-menu__overflow-item--active': isActiveLink(pathname, child.link),
+                })}
+                onClick={close}
+              >
+                {child.text}
+              </RouteLink>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Render an entry inside the "More" overflow popover. Leaf items become
+ * a single menu link; dropdown parents become a labelled group with
+ * their children listed beneath.
+ *
+ * @private
+ * @param props - The item, current pathname, and a navigate callback.
+ * @returns The overflow entry list element.
+ */
+function OverflowEntry(props: {
+  readonly item: CiderpressNavMenuItem
+  readonly pathname: string
+  readonly onNavigate: () => void
+}): React.ReactElement {
+  const { item, pathname, onNavigate } = props
+  const children = item.items ?? []
+  return match(children.length > 0)
+    .with(true, () => (
+      <li className="cp-nav-menu__overflow-group" role="none">
+        <span className="cp-nav-menu__overflow-group-label" aria-hidden="true">
+          {item.text}
+        </span>
+        <ul className="cp-nav-menu__overflow-sublist" role="menu" aria-label={item.text}>
+          {children.map((child, index) => (
+            <li key={`${itemKey(child)}::${index}`} role="none">
+              <RouteLink
+                href={child.link ?? '#'}
+                role="menuitem"
+                className={clsx('cp-nav-menu__overflow-item', {
+                  'cp-nav-menu__overflow-item--active': isActiveLink(pathname, child.link),
+                })}
+                onClick={onNavigate}
+              >
+                {child.text}
+              </RouteLink>
+            </li>
+          ))}
+        </ul>
+      </li>
+    ))
+    .otherwise(() => (
+      <li role="none">
+        <RouteLink
+          href={item.link ?? '#'}
+          role="menuitem"
+          className={clsx('cp-nav-menu__overflow-item', {
+            'cp-nav-menu__overflow-item--active': isActiveLink(pathname, item.link),
+          })}
+          onClick={onNavigate}
+        >
+          {item.text}
+        </RouteLink>
+      </li>
+    ))
+}
+
+/**
+ * Whether a nav item carries a non-empty `items` array (making it a
+ * dropdown parent rather than a leaf).
+ *
+ * @private
+ * @param item - Nav item to test.
+ * @returns True when the item has at least one child.
+ */
+function hasChildren(item: CiderpressNavMenuItem): boolean {
+  return item.items !== undefined && item.items.length > 0
+}
+
+/**
+ * Stable React key for a nav item — its link when present, otherwise
+ * its label (dropdown parents may have no link of their own).
+ *
+ * @private
+ * @param item - Nav item to key.
+ * @returns Key string.
+ */
+function itemKey(item: CiderpressNavMenuItem): string {
+  if (item.link !== undefined && item.link !== '') {
+    return item.link
+  }
+  return item.text
+}
+
+/**
+ * Active-route test that tolerates an absent link (dropdown parents),
+ * delegating to {@link isActive} only when a link is present.
+ *
+ * @private
+ * @param pathname - Current route pathname.
+ * @param link - Item link, possibly undefined.
+ * @returns True when the link is present and matches the route.
+ */
+function isActiveLink(pathname: string, link: string | undefined): boolean {
+  if (link === undefined) {
+    return false
+  }
+  return isActive(pathname, link)
+}
 
 /**
  * Walk the per-item widths left-to-right, accumulating until we'd
@@ -275,34 +563,99 @@ function gapAt(index: number, gap: number): number {
 }
 
 /**
- * Read every anchor under Rspress's hidden `.rp-nav-menu` and project
- * it into a `{ text, link }` item. Anchors with empty text or `href`
- * are dropped so we never surface a placeholder entry.
+ * Reconstruct the primary nav from Rspress's hidden `.rp-nav-menu`,
+ * preserving dropdowns. Each top-level `.rp-nav-menu__item` is either a
+ * leaf (its container is an anchor) or a dropdown parent (it wraps a
+ * `.rp-hover-group` of child links). Items with empty text, or dropdown
+ * parents with no usable children, are dropped.
  *
  * @private
  * @returns Nav items currently in the DOM (empty array when not mounted).
  */
 function scrapeNavItems(): readonly CiderpressNavMenuItem[] {
-  const anchors = document.querySelectorAll<HTMLAnchorElement>('.rp-nav-menu .rp-nav-menu__item a')
+  return navMenuRoots()
+    .map(scrapeNavItem)
+    .filter((item): item is CiderpressNavMenuItem => item !== null)
+}
+
+/**
+ * Collect the top-level `.rp-nav-menu__item` `<li>`s to scrape. Rspress
+ * renders separate left and right nav `<ul>`s; the ciderpress topbar is
+ * right-aligned, so we read the right menu and only fall back to the
+ * unscoped selector when it isn't present.
+ *
+ * @private
+ * @returns Top-level nav item elements.
+ */
+function navMenuRoots(): readonly HTMLElement[] {
+  const right = document.querySelectorAll<HTMLElement>('.rp-nav-menu--right > .rp-nav-menu__item')
+  if (right.length > 0) {
+    return [...right]
+  }
+  return [...document.querySelectorAll<HTMLElement>('.rp-nav-menu > .rp-nav-menu__item')]
+}
+
+/**
+ * Project a single top-level `.rp-nav-menu__item` element into a nav
+ * item, recursing one level into its `.rp-hover-group` dropdown when
+ * present.
+ *
+ * @private
+ * @param root - Top-level nav `<li>` element.
+ * @returns Parsed nav item, or `null` when unusable.
+ */
+function scrapeNavItem(root: HTMLElement): CiderpressNavMenuItem | null {
+  const container = root.querySelector(':scope > .rp-nav-menu__item__container')
+  if (container === null) {
+    return null
+  }
+  const text = readElementText(container)
+  if (text === '') {
+    return null
+  }
+  const group = root.querySelector(':scope > .rp-hover-group')
+  if (group !== null) {
+    const items = scrapeGroupItems(group)
+    if (items.length === 0) {
+      return null
+    }
+    return { text, items }
+  }
+  const href = container.getAttribute('href')
+  if (href === null || href === '') {
+    return null
+  }
+  return { text, link: href }
+}
+
+/**
+ * Read the child links out of a Rspress `.rp-hover-group` dropdown.
+ *
+ * @private
+ * @param group - The `.rp-hover-group` element.
+ * @returns Child nav items with text + link (empties dropped).
+ */
+function scrapeGroupItems(group: Element): readonly CiderpressNavMenuItem[] {
+  const anchors = group.querySelectorAll<HTMLAnchorElement>('.rp-hover-group__item__link')
   return [...anchors]
     .map((anchor) => ({
-      text: readAnchorText(anchor),
+      text: readElementText(anchor),
       link: anchor.getAttribute('href') ?? '',
     }))
     .filter((item) => item.text !== '' && item.link !== '')
 }
 
 /**
- * Pull the trimmed text content from an anchor. Returns an empty
+ * Pull the trimmed text content from an element. Returns an empty
  * string when `textContent` is missing — callers treat empty as "skip
- * this anchor".
+ * this element".
  *
  * @private
- * @param anchor - Anchor element to read.
+ * @param element - Element to read.
  * @returns Trimmed inner text, or empty string when absent.
  */
-function readAnchorText(anchor: HTMLAnchorElement): string {
-  const text = anchor.textContent
+function readElementText(element: Element): string {
+  const text = element.textContent
   if (text === null) {
     return ''
   }

--- a/packages/ui/src/theme/components/nav/layout.tsx
+++ b/packages/ui/src/theme/components/nav/layout.tsx
@@ -193,13 +193,65 @@ function readNavItems(site: unknown): readonly CiderpressNavMenuItem[] {
   if (!Array.isArray(candidate)) {
     return []
   }
-  return candidate.filter(
-    (item): item is CiderpressNavMenuItem =>
-      typeof item === 'object' &&
-      item !== null &&
-      typeof (item as { text?: unknown }).text === 'string' &&
-      typeof (item as { link?: unknown }).link === 'string'
-  )
+  return candidate.map(toNavItem).filter((item): item is CiderpressNavMenuItem => item !== null)
+}
+
+/**
+ * Coerce one raw Rspress nav entry into a `CiderpressNavMenuItem`,
+ * recursing into `items` for dropdown parents. Entries missing a
+ * string `text`, or that are neither a link nor a non-empty dropdown,
+ * are dropped (returned as `null`).
+ *
+ * @private
+ * @param raw - Untyped nav entry read off `site.nav`
+ * @returns Parsed nav item, or `null` when the entry is unusable
+ */
+function toNavItem(raw: unknown): CiderpressNavMenuItem | null {
+  if (typeof raw !== 'object' || raw === null) {
+    return null
+  }
+  const record = raw as {
+    readonly text?: unknown
+    readonly link?: unknown
+    readonly items?: unknown
+  }
+  if (typeof record.text !== 'string') {
+    return null
+  }
+  const link = match(record.link)
+    .with(P.string, (value) => value)
+    .otherwise(() => undefined)
+  const items = match(Array.isArray(record.items))
+    .with(true, () =>
+      (record.items as readonly unknown[])
+        .map(toNavItem)
+        .filter((child): child is CiderpressNavMenuItem => child !== null)
+    )
+    .otherwise(() => [])
+  return buildNavItem({ text: record.text, link, items })
+}
+
+/**
+ * Assemble a `CiderpressNavMenuItem` from its parsed parts, keeping
+ * only the properties that are actually present so the result matches
+ * the optional-field contract. Returns `null` for a dead entry (no
+ * link and no children).
+ *
+ * @private
+ * @param params - The parsed text, optional link, and child items
+ * @returns A nav item, or `null` when there is nothing to render
+ */
+function buildNavItem(params: {
+  readonly text: string
+  readonly link: string | undefined
+  readonly items: readonly CiderpressNavMenuItem[]
+}): CiderpressNavMenuItem | null {
+  const { text, link, items } = params
+  return match({ hasLink: link !== undefined, hasItems: items.length > 0 })
+    .with({ hasLink: true, hasItems: true }, () => ({ text, link, items }))
+    .with({ hasLink: true, hasItems: false }, () => ({ text, link }))
+    .with({ hasLink: false, hasItems: true }, () => ({ text, items }))
+    .otherwise(() => null)
 }
 
 /**

--- a/packages/ui/src/theme/hooks/use-nav-items.ts
+++ b/packages/ui/src/theme/hooks/use-nav-items.ts
@@ -41,34 +41,99 @@ export function useNavItems(): readonly CiderpressNavMenuItem[] {
 }
 
 /**
- * Read every anchor under Rspress's hidden `.rp-nav-menu` and project
- * it into a `{ text, link }` item. Anchors with empty text or `href`
- * are dropped so we never surface a placeholder entry.
+ * Reconstruct the primary nav from Rspress's hidden `.rp-nav-menu`,
+ * preserving dropdowns. Each top-level `.rp-nav-menu__item` is either a
+ * leaf (its container is an anchor) or a dropdown parent (it wraps a
+ * `.rp-hover-group` of child links). Items with empty text, or dropdown
+ * parents with no usable children, are dropped.
  *
  * @private
  * @returns Nav items currently in the DOM (empty array when not mounted).
  */
 function scrapeNavItems(): readonly CiderpressNavMenuItem[] {
-  const anchors = document.querySelectorAll<HTMLAnchorElement>('.rp-nav-menu .rp-nav-menu__item a')
+  return navMenuRoots()
+    .map(scrapeNavItem)
+    .filter((item): item is CiderpressNavMenuItem => item !== null)
+}
+
+/**
+ * Collect the top-level `.rp-nav-menu__item` `<li>`s to scrape. Rspress
+ * renders separate left and right nav `<ul>`s; the ciderpress topbar is
+ * right-aligned, so we read the right menu and only fall back to the
+ * unscoped selector when it isn't present.
+ *
+ * @private
+ * @returns Top-level nav item elements.
+ */
+function navMenuRoots(): readonly HTMLElement[] {
+  const right = document.querySelectorAll<HTMLElement>('.rp-nav-menu--right > .rp-nav-menu__item')
+  if (right.length > 0) {
+    return [...right]
+  }
+  return [...document.querySelectorAll<HTMLElement>('.rp-nav-menu > .rp-nav-menu__item')]
+}
+
+/**
+ * Project a single top-level `.rp-nav-menu__item` element into a nav
+ * item, recursing one level into its `.rp-hover-group` dropdown when
+ * present.
+ *
+ * @private
+ * @param root - Top-level nav `<li>` element.
+ * @returns Parsed nav item, or `null` when unusable.
+ */
+function scrapeNavItem(root: HTMLElement): CiderpressNavMenuItem | null {
+  const container = root.querySelector(':scope > .rp-nav-menu__item__container')
+  if (container === null) {
+    return null
+  }
+  const text = readElementText(container)
+  if (text === '') {
+    return null
+  }
+  const group = root.querySelector(':scope > .rp-hover-group')
+  if (group !== null) {
+    const items = scrapeGroupItems(group)
+    if (items.length === 0) {
+      return null
+    }
+    return { text, items }
+  }
+  const href = container.getAttribute('href')
+  if (href === null || href === '') {
+    return null
+  }
+  return { text, link: href }
+}
+
+/**
+ * Read the child links out of a Rspress `.rp-hover-group` dropdown.
+ *
+ * @private
+ * @param group - The `.rp-hover-group` element.
+ * @returns Child nav items with text + link (empties dropped).
+ */
+function scrapeGroupItems(group: Element): readonly CiderpressNavMenuItem[] {
+  const anchors = group.querySelectorAll<HTMLAnchorElement>('.rp-hover-group__item__link')
   return [...anchors]
     .map((anchor) => ({
-      text: readAnchorText(anchor),
+      text: readElementText(anchor),
       link: anchor.getAttribute('href') ?? '',
     }))
     .filter((item) => item.text !== '' && item.link !== '')
 }
 
 /**
- * Pull the trimmed text content from an anchor. Returns an empty
+ * Pull the trimmed text content from an element. Returns an empty
  * string when `textContent` is missing — callers treat empty as "skip
- * this anchor".
+ * this element".
  *
  * @private
- * @param anchor - Anchor element to read.
+ * @param element - Element to read.
  * @returns Trimmed inner text, or empty string when absent.
  */
-function readAnchorText(anchor: HTMLAnchorElement): string {
-  const text = anchor.textContent
+function readElementText(element: Element): string {
+  const text = element.textContent
   if (text === null) {
     return ''
   }


### PR DESCRIPTION
## Summary

Topbar nav dropdowns/submenus were fully plumbed through config, schema, and the CLI sync engine, but the custom theme's nav layer dropped them — `readNavItems` required every item to have a `link`, so dropdown parents (which have `items` and no `link`) never rendered. This PR wires the UI layer to actually paint them, on both desktop and mobile.

## Changes

- **Widened `CiderpressNavMenuItem`** (`@ciderpress/ui` exported API): `link` is now optional and a recursive `items` array is supported, matching the config-side `NavItem` shape.
- **Parsing:** `readNavItems` now recursively parses dropdown parents from `site.nav`; the DOM-scrape fallback reconstructs dropdowns from Rspress's `.rp-hover-group` markup, scoped to the right-aligned nav menu.
- **Desktop dropdown:** hover-to-preview + click-to-pin state model (`open = hovering || pinned`), an invisible hover bridge across the toggle→menu gap, a 220ms close grace period, Escape-to-close with focus return, and outside-click dismissal. Popover is right-anchored and offset 12px below the toggle.
- **Mobile:** collapsible accordion group in the hamburger drawer (collapsed by default, rotating chevron, `aria-expanded`, `role="group"`).
- **Overflow "More" popover** renders dropdown parents as labelled sub-groups.
- Hardening from adversarial review: unique React keys, AA-contrast group labels (`--cp-c-text-2`), and measurement that accounts for the dropdown chevron width.
- **Demo:** the `simple` example gains a "Reference" dropdown so the feature is visible.

## Testing

- `pnpm check` (typecheck + lint + format) passes, 16/16 tasks.
- Verified live in the `simple` example with Playwright + screenshots: desktop hover/pin/close and cross-gap behavior, keyboard (Enter to open, Tab through, Escape returns focus), and the mobile accordion expand/collapse.

## Notes

- Three fresh-context review agents (rule compliance, functional correctness, a11y) reviewed the diff; their high-value findings are folded in.
- Follow-up worth considering: the dropdown reuses the pre-existing overflow popover's `role="menu"`/`menuitem` semantics for consistency. An a11y reviewer argued these should be a plain disclosure pattern (links-in-a-popover) since there's no arrow-key roving — a separate refactor that would also touch the existing "More" overflow.