### PR TITLE
fix(repo): build example sites serially to stop Vercel OOM hang

### DIFF
--- a/scripts/build.lauf.ts
+++ b/scripts/build.lauf.ts
@@ -55,15 +55,24 @@ export default lauf({
     }
 
     ctx.spinner.start(`Building ${examples.length} example ${plural(examples.length, 'site')}`)
-    const exampleResults = await Promise.all(
-      examples.map((example) =>
-        runExampleBuild({
+    // Build examples serially, not with Promise.all. Each example spawns its
+    // own rspack, which itself forks CPU-count minifier workers, so a parallel
+    // fan-out peaks ~9 GB locally — past CI build containers' memory ceiling
+    // (Vercel's default is 8 GB). Overshooting OOM-kills a worker; rspack then
+    // hangs waiting on the dead worker instead of erroring, so the build never
+    // finishes and the deploy times out. Serial caps peak to one rspack build.
+    const exampleResults = await examples.reduce<Promise<readonly number[]>>(
+      async (accP, example) => {
+        const acc = await accP
+        const code = await runExampleBuild({
           pkg: example.pkg,
           cwd: root,
           env: { CIDERPRESS_BASE: example.mountBase },
           logger: ctx.logger,
         })
-      )
+        return [...acc, code]
+      },
+      Promise.resolve([])
     )
     const failedExamples = exampleResults
       .map((code, i) => ({ code, example: examples[i] }))


### PR DESCRIPTION
## Summary

Vercel deploys (production on \`main\` and some PR previews) never finished — they ran until Vercel's build timeout and reported the check as failed. Root cause: the docs build fanned out **all example builds in parallel** (\`Promise.all\` in \`scripts/build.lauf.ts\`). Each example spawns its own rspack, which forks CPU-count minifier workers, so the fan-out peaked **~9.4 GB across ~89 processes** locally — past Vercel's **8 GB** build container. The overshoot OOM-kills a rspack worker; rspack then hangs waiting on the dead worker instead of erroring, so the build hangs to timeout.

It was intermittent (some previews passed) because it sat right on the memory ceiling.

## Changes

- Build example sites **serially** instead of via \`Promise.all\`, bounding peak memory to one rspack build at a time (measured peak drops to ~5–7 GB).

## Testing

- Reproduced the exact Vercel \`buildCommand\` locally under \`CI=1 VERCEL=1\` non-TTY env — builds complete (the machine has enough RAM to survive the fan-out).
- Sampled memory: parallel = **9.4 GB peak / 89 procs**; serial = **~5–7 GB sustained** (one transient root-build spike).
- \`oxlint\` + \`oxfmt\` clean.
- Validated on this preview.

## Related

Follow-up from #131 (which enabled a preview on every PR and surfaced this).