### PR TITLE
feat(packages/templates,packages/cli): template fill variables + {{ }} marker convention

### DIFF
--- a/.changeset/template-fill-variables.md
+++ b/.changeset/template-fill-variables.md
@@ -1,0 +1,11 @@
+---
+'@ciderpress/templates': minor
+'@ciderpress/cli': minor
+---
+
+Add template fill variables and a `{{ }}` marker convention.
+
+Templates can now declare fillable variables in frontmatter, `draft` resolves them from arguments or prompts, and any unfilled marker passes through as a raw `{{ }}` marker for a human or agent to complete. The validator no longer rejects non-`{{title}}` markers (fixes the case where registered templates using the convention broke `build`/`check`), and a new lint fails when a published doc still contains one.
+
+- **`@ciderpress/templates`** — `Template` gains an optional `vars: TemplateVar[]` (each `{ id, title?, description? }`); `buildTemplate()` validates `vars` and no longer emits `unknown_placeholder` (replaced by `invalid_vars`); `render()` now tolerates interior whitespace (`{{ title }}` === `{{title}}`) and leaves unmatched markers untouched; new `findMarkers()` export lists remaining markers.
+- **`@ciderpress/cli`** — `ciderpress draft` gains a repeatable `--var id=value`, always substitutes the built-in `title`/`slug`/`date`/`filename` variables, prompts for declared vars on an interactive terminal (skipping leaves the raw marker), and prints a checklist of unfilled markers. `ciderpress check` and `ciderpress build --check` now fail on unfilled `{{ }}` markers in synced docs (fenced/inline code excluded).

--- a/docs/framework/templates.md
+++ b/docs/framework/templates.md
@@ -104,7 +104,7 @@ At draft time each declared variable is filled from a `--var id=value` argument,
 
 ### The no-leftover-markers lint
 
-`ciderpress check` and `ciderpress build` fail when a **published** doc still contains a `{{ }}` marker, so a half-filled draft can't ship. Markers inside fenced or inline code are ignored, so docs that _demonstrate_ the convention (like this one) don't trip it.
+`ciderpress check` and `ciderpress build` fail when a **published** doc still contains a `{{ }}` marker, so a half-filled draft can't ship. Markers inside fenced or inline code are ignored, so docs that _demonstrate_ the convention (like this one) don't trip it. A marker's key is limited to identifier and phrase characters, so JSX/MDX inline objects such as `style={{ color: 'red' }}` are never mistaken for markers.
 
 ## Listing and validating
 

--- a/docs/framework/templates.md
+++ b/docs/framework/templates.md
@@ -20,9 +20,12 @@ ciderpress draft --type guide --title "Deploy to Vercel"
 
 # Output to a specific directory
 ciderpress draft --type guide --title "Deploy to Vercel" --out docs/guides
+
+# Fill declared variables up front (repeatable)
+ciderpress draft --type adr --title "Use Postgres" --var decision="Adopt Postgres"
 ```
 
-This renders the template with your title and writes it to the output directory.
+This renders the template with your title (plus any variables) and writes it to the output directory. Variables you don't supply are left as raw `{{ }}` markers for you — or a coding agent — to fill in later, and `draft` prints a checklist of what remains.
 
 ## Custom templates
 
@@ -35,7 +38,7 @@ export default defineConfig({
 })
 ```
 
-Each template is a plain `.md` or `.mdx` file with `label` and `hint` frontmatter. The **filename is the type** (`adr.md` becomes type `adr`), and `{{title}}` is the only supported placeholder:
+Each template is a plain `.md` or `.mdx` file with `label` and `hint` frontmatter. The **filename is the type** (`adr.md` becomes type `adr`):
 
 ```md
 ---
@@ -56,17 +59,64 @@ hint: Architecture decision record
 - A custom template whose filename matches a built-in **overrides** it — a `guide.md` replaces the bundled Guide.
 - Frontmatter is always stripped from the scaffolded output.
 
+## Variables
+
+A template body can contain `{{ marker }}` variables. Interior whitespace is ignored, so `{{title}}` and `{{ title }}` are equivalent.
+
+**Built-in variables** are always substituted at draft time:
+
+| Variable       | Value                                        |
+| -------------- | -------------------------------------------- |
+| `{{title}}`    | The `--title` you pass (or are prompted for) |
+| `{{slug}}`     | Kebab-case slug of the title                 |
+| `{{date}}`     | Today's date, `YYYY-MM-DD`                   |
+| `{{filename}}` | The output filename (slug + extension)       |
+
+**Declared variables** are the fillable blanks a template names under `vars`. Only `id` is required; `title` and `description` drive the interactive prompt:
+
+```md
+---
+label: ADR
+hint: Architecture decision record
+vars:
+  - id: decision
+    title: Decision
+    description: The change being proposed or made
+  - id: consequences
+---
+
+# {{title}}
+
+- **Date:** {{date}}
+
+## Decision
+
+{{ decision }}
+
+## Consequences
+
+{{ consequences }}
+```
+
+At draft time each declared variable is filled from a `--var id=value` argument, then — on an interactive terminal — prompted for. Anything left blank (or every declared variable when running non-interactively, e.g. from a coding agent) stays as a raw `{{ id }}` marker.
+
+**Undeclared markers** pass through untouched as plain text — no error, no substitution. This lets you leave hand-authored blanks a template doesn't formally declare.
+
+### The no-leftover-markers lint
+
+`ciderpress check` and `ciderpress build` fail when a **published** doc still contains a `{{ }}` marker, so a half-filled draft can't ship. Markers inside fenced or inline code are ignored, so docs that _demonstrate_ the convention (like this one) don't trip it.
+
 ## Listing and validating
 
 ```bash
 # List built-in and custom templates (overrides marked with *)
 ciderpress templates list
 
-# Validate template frontmatter and placeholder syntax
+# Validate template frontmatter and vars
 ciderpress templates check
 ```
 
-Template validation also runs as part of `ciderpress check` and `ciderpress build`.
+Template validation also runs as part of `ciderpress check` and `ciderpress build`, alongside the [no-leftover-markers lint](#the-no-leftover-markers-lint).
 
 ## Using the SDK
 
@@ -96,6 +146,15 @@ const extended = registry.extend('guide', {
 })
 ```
 
+`render` substitutes only the keys you pass and leaves the rest as raw markers. Use `findMarkers` to list what remains:
+
+```ts
+import { findMarkers, render } from '@ciderpress/templates'
+
+const output = render(adr, { title: 'Use Postgres' })
+findMarkers(output) // e.g. ['{{ decision }}', '{{ consequences }}']
+```
+
 ## Available templates
 
 | Template                            | Type              | Diataxis quadrant |
@@ -109,7 +168,7 @@ const extended = registry.extend('guide', {
 | [Troubleshooting](#troubleshooting) | `troubleshooting` | —                 |
 | [Runbook](#runbook)                 | `runbook`         | —                 |
 
-Templates use `{{title}}` as the placeholder, which is replaced when rendering.
+These built-in templates use `{{title}}`; see [Variables](#variables) for the full substitution model.
 
 ## Tutorial
 

--- a/docs/references/cli.md
+++ b/docs/references/cli.md
@@ -184,16 +184,19 @@ Validates the config file, syncs content, then runs a build to detect deadlinks.
 Scaffold a new documentation file from a template.
 
 ```bash
-ciderpress draft [--type <type>] [--title <title>] [--out <dir>]
+ciderpress draft [--type <type>] [--title <title>] [--out <dir>] [--var <id=value>...]
 ```
 
-| Flag      | Type     | Default | Description                         |
-| --------- | -------- | ------- | ----------------------------------- |
-| `--type`  | `string` | —       | Template type (prompts if omitted)  |
-| `--title` | `string` | —       | Document title (prompts if omitted) |
-| `--out`   | `string` | `"."`   | Output directory for the new file   |
+| Flag      | Type       | Default | Description                                       |
+| --------- | ---------- | ------- | ------------------------------------------------- |
+| `--type`  | `string`   | —       | Template type (prompts if omitted)                |
+| `--title` | `string`   | —       | Document title (prompts if omitted)               |
+| `--out`   | `string`   | `"."`   | Output directory for the new file                 |
+| `--var`   | `string[]` | —       | Fill a template variable, `id=value` (repeatable) |
 
 When `--type` or `--title` are omitted, an interactive prompt lets you select from the available templates and enter a title. The output filename is derived from the title slug (e.g. `"Authentication"` → `authentication.md`).
+
+Built-in variables (`{{title}}`, `{{slug}}`, `{{date}}`, `{{filename}}`) are always substituted. A template's declared `vars` are filled from `--var`, then prompted for on an interactive terminal; anything left blank stays as a raw `{{ id }}` marker and is reported as a checklist. See [Variables](/framework/templates#variables).
 
 The available templates are the built-ins plus any declared via the [`templates`](/reference/configuration) config field. A custom template whose filename matches a built-in overrides it, and `.mdx` templates scaffold to `.mdx` files. See [Templates](/framework/templates) for the authoring format.
 
@@ -209,9 +212,9 @@ ciderpress templates check   # Validate template frontmatter and syntax
 | Subcommand | Description                                                                       |
 | ---------- | --------------------------------------------------------------------------------- |
 | `list`     | Print built-in and custom templates, grouped by source; overrides marked with `*` |
-| `check`    | Validate every template's frontmatter and placeholders; exits `1` on any issue    |
+| `check`    | Validate every template's frontmatter and `vars`; exits `1` on any issue          |
 
-`check` reports frontmatter errors (missing/unknown fields), invalid types, unknown `{{placeholders}}`, and duplicate types. The same validation runs as part of [`check`](#check) and [`build`](#build). See [Templates](/framework/templates) for how to declare and author custom templates.
+`check` reports frontmatter errors (missing/unknown fields), invalid types, invalid `vars`, and duplicate types. `{{ }}` markers in a template body are always allowed. The same validation runs as part of [`check`](#check) and [`build`](#build), which additionally fail on unfilled markers in published docs. See [Templates](/framework/templates) for how to declare and author custom templates.
 
 ## References
 

--- a/examples/simple/.templates/adr.md
+++ b/examples/simple/.templates/adr.md
@@ -1,21 +1,28 @@
 ---
 label: ADR
 hint: Architecture decision record
+vars:
+  - id: decision
+    title: Decision
+    description: The change being proposed or made
+  - id: consequences
+    title: Consequences
+    description: What becomes easier or harder as a result
 ---
 
 # {{title}}
 
-- **Status:** proposed
-- **Date:** YYYY-MM-DD
+- **Status:** {{ status }}
+- **Date:** {{date}}
 
 ## Context
 
-What is the issue we're seeing that motivates this decision?
+{{ context }}
 
 ## Decision
 
-What is the change we're proposing or doing?
+{{ decision }}
 
 ## Consequences
 
-What becomes easier or harder as a result?
+{{ consequences }}

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -6,7 +6,13 @@ import { z } from 'zod'
 
 import { generateAssets } from '../lib/banner/index.ts'
 import type { AssetConfig } from '../lib/banner/index.ts'
-import { presentResults, runBuildCheck, runConfigCheck, runTemplatesCheck } from '../lib/check.ts'
+import {
+  presentResults,
+  runBuildCheck,
+  runConfigCheck,
+  runMarkersCheck,
+  runTemplatesCheck,
+} from '../lib/check.ts'
 import { createPaths } from '../lib/paths.ts'
 import { buildSite } from '../lib/rspress.ts'
 import { sync } from '../lib/sync/index.ts'
@@ -74,10 +80,22 @@ export default command({
 
       await runAssetGeneration({ config, paths, log: ctx.log, quiet: true })
 
+      ctx.log.step('Checking for unfilled markers...')
+      const markersResult = await runMarkersCheck({
+        contentDir: paths.contentDir,
+        repoRoot: paths.repoRoot,
+      })
+
       ctx.log.step('Building & checking for broken links...')
       const buildResult = await runBuildCheck({ config, paths, verbose })
 
-      const passed = presentResults({ configResult, templatesResult, buildResult, logger: ctx.log })
+      const passed = presentResults({
+        configResult,
+        templatesResult,
+        markersResult,
+        buildResult,
+        logger: ctx.log,
+      })
       if (!passed) {
         ctx.log.outro('Build failed')
         process.exit(1)

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -1,7 +1,13 @@
 import { loadConfig } from '@ciderpress/config/loader'
 import { command } from '@kidd-cli/core'
 
-import { presentResults, runBuildCheck, runConfigCheck, runTemplatesCheck } from '../lib/check.ts'
+import {
+  presentResults,
+  runBuildCheck,
+  runConfigCheck,
+  runMarkersCheck,
+  runTemplatesCheck,
+} from '../lib/check.ts'
 import { createPaths } from '../lib/paths.ts'
 import { sync } from '../lib/sync/index.ts'
 
@@ -24,8 +30,9 @@ export default command({
     // If config is invalid, present the error and bail — sync/build need valid config
     if (configErr || !config) {
       const templatesResult = { status: 'skipped' } as const
+      const markersResult = { status: 'skipped' } as const
       const buildResult = { status: 'skipped' } as const
-      presentResults({ configResult, templatesResult, buildResult, logger: ctx.log })
+      presentResults({ configResult, templatesResult, markersResult, buildResult, logger: ctx.log })
       ctx.log.outro('Checks failed')
       process.exit(1)
     }
@@ -43,10 +50,22 @@ export default command({
       `Synced (${syncResult.pagesWritten} written, ${syncResult.pagesSkipped} unchanged)`
     )
 
+    ctx.log.step('Checking for unfilled markers...')
+    const markersResult = await runMarkersCheck({
+      contentDir: paths.contentDir,
+      repoRoot: paths.repoRoot,
+    })
+
     ctx.log.step('Checking for broken links...')
     const buildResult = await runBuildCheck({ config, paths })
 
-    const passed = presentResults({ configResult, templatesResult, buildResult, logger: ctx.log })
+    const passed = presentResults({
+      configResult,
+      templatesResult,
+      markersResult,
+      buildResult,
+      logger: ctx.log,
+    })
 
     if (passed) {
       ctx.log.outro('All checks passed')

--- a/packages/cli/src/commands/draft.ts
+++ b/packages/cli/src/commands/draft.ts
@@ -2,13 +2,16 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import { loadConfig } from '@ciderpress/config/loader'
-import { render, toSlug } from '@ciderpress/templates'
+import { findMarkers, render, toSlug } from '@ciderpress/templates'
+import type { TemplateVar, TemplateVariables } from '@ciderpress/templates'
+import type { Prompts } from '@kidd-cli/core'
 import { command } from '@kidd-cli/core'
 import { match, P } from 'massaman/match'
 import { z } from 'zod'
 
 import { createPaths } from '../lib/paths.ts'
 import { configTemplates, resolveTemplates, toTemplateSelectOptions } from '../lib/templates.ts'
+import { buildBuiltInVars, parseVarArgs } from '../lib/vars.ts'
 
 /**
  * Scaffold a new documentation file from a template.
@@ -19,6 +22,13 @@ import { configTemplates, resolveTemplates, toTemplateSelectOptions } from '../l
  * `templates` config field are merged with the built-ins (user templates
  * override built-ins by type); when no config or `templates` field is present,
  * only built-ins are offered.
+ *
+ * Built-in variables (`title`, `slug`, `date`, `filename`) are always
+ * substituted. A template's declared `vars` are filled from `--var id=value`
+ * arguments, then — on an interactive terminal — prompted for; any left blank
+ * (or every declared var when running non-interactively) stay as raw `{{ id }}`
+ * markers for a human or agent to fill in later, and are reported as a
+ * checklist. Undeclared `{{ }}` markers always pass through untouched.
  */
 export default command({
   name: 'draft',
@@ -27,6 +37,10 @@ export default command({
     type: z.string().optional(),
     title: z.string().optional(),
     out: z.string().optional().default('.'),
+    var: z
+      .array(z.string())
+      .optional()
+      .describe('Fill a template variable, repeatable: --var id=value'),
   }),
   handler: async (ctx) => {
     ctx.log.intro('ciderpress draft')
@@ -78,9 +92,25 @@ export default command({
       return
     }
 
-    const content = render(template, { title })
     const extension = template.extension ?? '.md'
     const filename = `${slug}${extension}`
+
+    const { values: argVars, invalid } = parseVarArgs(ctx.args.var)
+    if (invalid.length > 0) {
+      ctx.log.warn(`Ignoring malformed --var (expected id=value): ${invalid.join(', ')}`)
+    }
+
+    const filledVars = await resolveDeclaredVars({
+      vars: template.vars,
+      provided: argVars,
+      prompts: ctx.prompts,
+      interactive: process.stdout.isTTY === true,
+    })
+
+    const builtIns = buildBuiltInVars({ title, slug, filename, now: new Date() })
+    const variables: TemplateVariables = { ...argVars, ...filledVars, ...builtIns, title }
+
+    const content = render(template, variables)
     const outDir = path.resolve(process.cwd(), ctx.args.out)
     const filePath = path.join(outDir, filename)
 
@@ -98,6 +128,69 @@ export default command({
     await fs.writeFile(filePath, content, 'utf8')
 
     ctx.log.success(`Created ${path.relative(process.cwd(), filePath)}`)
+
+    const remaining = findMarkers(content)
+    if (remaining.length > 0) {
+      ctx.log.warn(`${remaining.length} marker(s) still to fill:`)
+      ctx.log.message(remaining.map((marker) => `  ${marker}`).join('\n'))
+    }
+
     ctx.log.outro('Done')
   },
 })
+
+/**
+ * Resolve a template's declared `vars` into a value map, filling each from the
+ * provided `--var` args, then — when interactive — prompting for the rest.
+ *
+ * Values are collected sequentially so prompts appear one at a time. A var
+ * already provided via args is not prompted; a var left blank (or every var
+ * when non-interactive) is omitted so {@link render} leaves its raw marker.
+ *
+ * @private
+ * @param input - Declared vars, provided arg values, the prompt API, and
+ *   whether the session is interactive
+ * @returns A map of resolved var id to value (omitting skipped vars)
+ */
+function resolveDeclaredVars(input: {
+  readonly vars: readonly TemplateVar[] | undefined
+  readonly provided: Readonly<Record<string, string>>
+  readonly prompts: Prompts
+  readonly interactive: boolean
+}): Promise<Readonly<Record<string, string>>> {
+  const { vars, provided, prompts, interactive } = input
+  if (vars === undefined || vars.length === 0) {
+    return Promise.resolve({})
+  }
+  return vars.reduce<Promise<Readonly<Record<string, string>>>>(async (accPromise, variable) => {
+    const acc = await accPromise
+    if (Object.hasOwn(provided, variable.id) || !interactive) {
+      return acc
+    }
+    const answer = await prompts.text({
+      message: promptMessage(variable),
+      placeholder: 'Leave blank to fill in later',
+    })
+    if (answer.trim().length === 0) {
+      return acc
+    }
+    return { ...acc, [variable.id]: answer }
+  }, Promise.resolve({}))
+}
+
+/**
+ * Build the prompt message for a declared var from its title/description,
+ * falling back to the id.
+ *
+ * @private
+ * @param variable - The declared template var
+ * @returns The prompt message string
+ */
+function promptMessage(variable: TemplateVar): string {
+  const label = match(variable.title)
+    .with(P.string.minLength(1), (title) => title)
+    .otherwise(() => variable.id)
+  return match(variable.description)
+    .with(P.string.minLength(1), (description) => `${label} — ${description}`)
+    .otherwise(() => label)
+}

--- a/packages/cli/src/commands/draft.ts
+++ b/packages/cli/src/commands/draft.ts
@@ -107,8 +107,10 @@ export default command({
       interactive: process.stdout.isTTY === true,
     })
 
+    // Built-in variables are resolved last so they always win over an
+    // arg/prompt collision (e.g. a stray `--var title=…`).
     const builtIns = buildBuiltInVars({ title, slug, filename, now: new Date() })
-    const variables: TemplateVariables = { ...argVars, ...filledVars, ...builtIns, title }
+    const variables: TemplateVariables = { ...argVars, ...filledVars, ...builtIns }
 
     const content = render(template, variables)
     const outDir = path.resolve(process.cwd(), ctx.args.out)

--- a/packages/cli/src/lib/check.test.ts
+++ b/packages/cli/src/lib/check.test.ts
@@ -51,6 +51,7 @@ describe('presentResults()', () => {
     const result = presentResults({
       configResult: { passed: true, errors: [], warnings: [] },
       templatesResult: { status: 'passed', count: 0 },
+      markersResult: { status: 'passed' },
       buildResult: { status: 'passed' },
       logger: mockLogger,
     })
@@ -61,6 +62,7 @@ describe('presentResults()', () => {
     const result = presentResults({
       configResult: { passed: false, errors: [loadError], warnings: [] },
       templatesResult: { status: 'passed', count: 0 },
+      markersResult: { status: 'passed' },
       buildResult: { status: 'passed' },
       logger: mockLogger,
     })
@@ -71,6 +73,7 @@ describe('presentResults()', () => {
     const result = presentResults({
       configResult: { passed: true, errors: [], warnings: [] },
       templatesResult: { status: 'passed', count: 0 },
+      markersResult: { status: 'passed' },
       buildResult: {
         status: 'failed',
         deadlinks: [{ file: 'docs/page.md', links: ['/missing'] }],
@@ -84,6 +87,7 @@ describe('presentResults()', () => {
     presentResults({
       configResult: { passed: true, errors: [], warnings: [] },
       templatesResult: { status: 'passed', count: 0 },
+      markersResult: { status: 'passed' },
       buildResult: { status: 'passed' },
       logger: mockLogger,
     })
@@ -94,9 +98,24 @@ describe('presentResults()', () => {
     presentResults({
       configResult: { passed: false, errors: [loadError], warnings: [] },
       templatesResult: { status: 'passed', count: 0 },
+      markersResult: { status: 'passed' },
       buildResult: { status: 'skipped' },
       logger: mockLogger,
     })
     expect(mockLogger.error).toHaveBeenCalledWith('Config validation failed:')
+  })
+
+  it('should return false when a doc has unfilled markers', () => {
+    const result = presentResults({
+      configResult: { passed: true, errors: [], warnings: [] },
+      templatesResult: { status: 'passed', count: 0 },
+      markersResult: {
+        status: 'failed',
+        issues: [{ file: 'content/adr.md', markers: ['{{ decision }}'] }],
+      },
+      buildResult: { status: 'passed' },
+      logger: mockLogger,
+    })
+    expect(result).toBe(false)
   })
 })

--- a/packages/cli/src/lib/check.ts
+++ b/packages/cli/src/lib/check.ts
@@ -16,6 +16,8 @@ import { toError } from 'massaman/conversion'
 import { sumBy } from 'massaman/math'
 import { isString } from 'massaman/predicate'
 
+import { scanMarkers } from './markers.ts'
+import type { MarkerIssue } from './markers.ts'
 import type { Paths } from './paths.ts'
 import { buildSiteForCheck } from './rspress.ts'
 import { checkWorkspaceIncludes } from './sync/workspace.ts'
@@ -52,6 +54,11 @@ type TemplatesCheckResult =
   | { readonly status: 'failed'; readonly issues: readonly TemplateIssue[] }
   | { readonly status: 'skipped' }
 
+type MarkersCheckResult =
+  | { readonly status: 'passed' }
+  | { readonly status: 'failed'; readonly issues: readonly MarkerIssue[] }
+  | { readonly status: 'skipped' }
+
 interface CaptureResult<T> {
   readonly result: T | null
   readonly error: Error | null
@@ -61,6 +68,7 @@ interface CaptureResult<T> {
 interface PresentResultsParams {
   readonly configResult: ConfigCheckResult
   readonly templatesResult: TemplatesCheckResult
+  readonly markersResult: MarkersCheckResult
   readonly buildResult: BuildCheckResult
   readonly logger: Log
 }
@@ -127,6 +135,27 @@ export async function runTemplatesCheck(params: {
 }
 
 /**
+ * Scan synced content for docs that still carry unfilled `{{ }}` fill markers.
+ *
+ * Runs after sync so it sees exactly what ships. Fails when any published doc
+ * retains a template's fill marker; templates themselves are not synced and so
+ * are excluded. Fenced and inline code are ignored (see {@link scanMarkers}).
+ *
+ * @param params - The synced content directory and repo root
+ * @returns A `MarkersCheckResult` with pass/fail status and any issues
+ */
+export async function runMarkersCheck(params: {
+  readonly contentDir: string
+  readonly repoRoot: string
+}): Promise<MarkersCheckResult> {
+  const issues = await scanMarkers({ contentDir: params.contentDir, repoRoot: params.repoRoot })
+  if (issues.length > 0) {
+    return { status: 'failed', issues }
+  }
+  return { status: 'passed' }
+}
+
+/**
  * Run a silent Rspress build to detect deadlinks.
  *
  * Rspress's `remarkLink` plugin checks internal links during build. In
@@ -171,7 +200,7 @@ export async function runBuildCheck(params: RunBuildCheckParams): Promise<BuildC
  * @returns `true` if all checks passed, `false` otherwise
  */
 export function presentResults(params: PresentResultsParams): boolean {
-  const { configResult, templatesResult, buildResult, logger } = params
+  const { configResult, templatesResult, markersResult, buildResult, logger } = params
 
   if (configResult.passed) {
     logger.success('Config valid')
@@ -200,6 +229,14 @@ export function presentResults(params: PresentResultsParams): boolean {
     logger.message(templatesResult.issues.map(formatTemplateIssue).join('\n'))
   }
 
+  if (markersResult.status === 'passed') {
+    logger.success('No unfilled markers')
+  } else if (markersResult.status === 'failed') {
+    const total = sumBy(markersResult.issues, (issue) => issue.markers.length)
+    logger.error(`Found ${total} unfilled marker(s):`)
+    logger.message(markersResult.issues.map(formatMarkerGroup).join('\n'))
+  }
+
   if (buildResult.status === 'passed') {
     logger.success('No broken links')
   } else if (buildResult.status === 'skipped') {
@@ -214,7 +251,10 @@ export function presentResults(params: PresentResultsParams): boolean {
   }
 
   return (
-    configResult.passed && templatesResult.status !== 'failed' && buildResult.status === 'passed'
+    configResult.passed &&
+    templatesResult.status !== 'failed' &&
+    markersResult.status !== 'failed' &&
+    buildResult.status === 'passed'
   )
 }
 
@@ -227,6 +267,20 @@ export function presentResults(params: PresentResultsParams): boolean {
  */
 function formatTemplateIssue(issue: TemplateIssue): string {
   return `  ${RED}✖${RESET} ${issue.file} ${DIM}—${RESET} ${issue.message}`
+}
+
+/**
+ * Format a single marker issue as a compact multi-line group, mirroring the
+ * deadlink report: a file header followed by each leftover marker.
+ *
+ * @private
+ * @param issue - The marker issue with file path and leftover markers
+ * @returns Formatted multi-line string for CLI output
+ */
+function formatMarkerGroup(issue: MarkerIssue): string {
+  const header = `  ${RED}✖${RESET} ${issue.file}`
+  const markers = issue.markers.map((marker) => `      ${DIM}→${RESET} ${marker}`)
+  return [header, ...markers].join('\n')
 }
 
 /**

--- a/packages/cli/src/lib/markers.test.ts
+++ b/packages/cli/src/lib/markers.test.ts
@@ -56,6 +56,12 @@ describe('scanMarkers()', () => {
     expect(issues).toStrictEqual([])
   })
 
+  it('should ignore JSX inline-style objects in mdx', async () => {
+    write('content/icons.mdx', "# Icons\n\n<span style={{ color: '#34d399', width: 36 }} />\n")
+    const issues = await scanMarkers({ contentDir: join(dir, 'content'), repoRoot: dir })
+    expect(issues).toStrictEqual([])
+  })
+
   it('should scan nested directories and mdx files', async () => {
     write('content/guides/deep.mdx', '# Deep\n\n{{ todo }}\n')
     const issues = await scanMarkers({ contentDir: join(dir, 'content'), repoRoot: dir })

--- a/packages/cli/src/lib/markers.test.ts
+++ b/packages/cli/src/lib/markers.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { scanMarkers } from './markers'
+
+// oxlint-disable-next-line functional/no-let -- per-test temp dir, reassigned in beforeEach
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ciderpress-markers-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+/**
+ * Write a content file into a sub-path of the current temp dir.
+ *
+ * @param name - Relative file path (sub-directories created as needed)
+ * @param body - Full file contents
+ */
+function write(name: string, body: string): void {
+  const full = join(dir, name)
+  mkdirSync(join(full, '..'), { recursive: true })
+  writeFileSync(full, body, 'utf8')
+}
+
+describe('scanMarkers()', () => {
+  it('should return no issues when content is clean', async () => {
+    write('content/guide.md', '# Guide\n\nAll filled in.\n')
+    const issues = await scanMarkers({ contentDir: join(dir, 'content'), repoRoot: dir })
+    expect(issues).toStrictEqual([])
+  })
+
+  it('should flag leftover markers in prose', async () => {
+    write('content/adr.md', '# Title\n\n{{ decision }} and {{ }}\n')
+    const issues = await scanMarkers({ contentDir: join(dir, 'content'), repoRoot: dir })
+    expect(issues).toStrictEqual([
+      { file: join('content', 'adr.md'), markers: ['{{ decision }}', '{{ }}'] },
+    ])
+  })
+
+  it('should ignore markers inside fenced code blocks', async () => {
+    write('content/doc.md', '# Doc\n\n```md\n{{ decision }}\n```\n')
+    const issues = await scanMarkers({ contentDir: join(dir, 'content'), repoRoot: dir })
+    expect(issues).toStrictEqual([])
+  })
+
+  it('should ignore markers inside inline code', async () => {
+    write('content/doc.md', '# Doc\n\nUse `{{ decision }}` as a marker.\n')
+    const issues = await scanMarkers({ contentDir: join(dir, 'content'), repoRoot: dir })
+    expect(issues).toStrictEqual([])
+  })
+
+  it('should scan nested directories and mdx files', async () => {
+    write('content/guides/deep.mdx', '# Deep\n\n{{ todo }}\n')
+    const issues = await scanMarkers({ contentDir: join(dir, 'content'), repoRoot: dir })
+    expect(issues).toStrictEqual([
+      { file: join('content', 'guides', 'deep.mdx'), markers: ['{{ todo }}'] },
+    ])
+  })
+
+  it('should return no issues when the content dir is absent', async () => {
+    const issues = await scanMarkers({ contentDir: join(dir, 'missing'), repoRoot: dir })
+    expect(issues).toStrictEqual([])
+  })
+})

--- a/packages/cli/src/lib/markers.ts
+++ b/packages/cli/src/lib/markers.ts
@@ -1,0 +1,121 @@
+/**
+ * Detects leftover `{{ }}` fill markers in synced documentation content.
+ *
+ * A doc scaffolded from a template but never finished still carries the
+ * template's `{{ id }}` markers. This scans the synced content (what actually
+ * ships) so `check`/`build --check` can fail before those markers reach a
+ * published site. Fenced and inline code are stripped first so docs that
+ * *demonstrate* the convention in code samples don't false-positive.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { findMarkers } from '@ciderpress/templates'
+import { attemptAsync } from 'massaman/control'
+
+const FENCED_BLOCK_PATTERN = /```[\s\S]*?```/g
+const TILDE_BLOCK_PATTERN = /~~~[\s\S]*?~~~/g
+const INLINE_CODE_PATTERN = /`[^`\n]*`/g
+
+/**
+ * A doc that still contains one or more unfilled `{{ }}` markers.
+ */
+export interface MarkerIssue {
+  /** File path relative to the repo root. */
+  readonly file: string
+  /** The distinct leftover markers found, each normalized to `{{ key }}`. */
+  readonly markers: readonly string[]
+}
+
+/**
+ * Scan synced content for docs that still carry unfilled `{{ }}` markers.
+ *
+ * Walks every `.md`/`.mdx` file under `contentDir`, strips fenced and inline
+ * code, and reports any remaining markers. Templates live outside the synced
+ * content, so they are naturally excluded.
+ *
+ * @param input - The synced content directory and repo root for relative paths
+ * @returns One issue per file with leftover markers (empty when all clean)
+ */
+export async function scanMarkers(input: {
+  readonly contentDir: string
+  readonly repoRoot: string
+}): Promise<readonly MarkerIssue[]> {
+  const { contentDir, repoRoot } = input
+  const files = await collectMarkdownFiles(contentDir)
+
+  const results = await Promise.all(
+    files.map(async (absPath) => {
+      const read = await attemptAsync(() => fs.readFile(absPath, 'utf8'))
+      if (!read.ok) {
+        return null
+      }
+      const markers = findMarkers(stripCode(read.value))
+      if (markers.length === 0) {
+        return null
+      }
+      return { file: path.relative(repoRoot, absPath), markers }
+    })
+  )
+
+  return results.flatMap((result) => {
+    if (result === null) {
+      return []
+    }
+    return [result]
+  })
+}
+
+/**
+ * Recursively collect every `.md`/`.mdx` file under a directory.
+ *
+ * @private
+ * @param dir - The directory to walk
+ * @returns Absolute paths of all markdown/MDX files found (empty on read error)
+ */
+async function collectMarkdownFiles(dir: string): Promise<readonly string[]> {
+  const read = await attemptAsync(() => fs.readdir(dir, { withFileTypes: true }))
+  if (!read.ok) {
+    return []
+  }
+  const entries = read.value
+
+  const here = entries
+    .filter((entry) => entry.isFile() && isMarkdown(entry.name))
+    .map((entry) => path.join(dir, entry.name))
+
+  const subDirs = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => collectMarkdownFiles(path.join(dir, entry.name)))
+  )
+
+  return [...here, ...subDirs.flat()]
+}
+
+/**
+ * Check whether a filename is a markdown or MDX document.
+ *
+ * @private
+ * @param name - The filename to inspect
+ * @returns True for `.md` and `.mdx` files
+ */
+function isMarkdown(name: string): boolean {
+  return name.endsWith('.md') || name.endsWith('.mdx')
+}
+
+/**
+ * Remove fenced code blocks and inline code spans so markers used purely as
+ * documentation examples are not treated as unfilled.
+ *
+ * @private
+ * @param text - The raw document text
+ * @returns The text with all code regions removed
+ */
+function stripCode(text: string): string {
+  return text
+    .replace(FENCED_BLOCK_PATTERN, '')
+    .replace(TILDE_BLOCK_PATTERN, '')
+    .replace(INLINE_CODE_PATTERN, '')
+}

--- a/packages/cli/src/lib/templates.test.ts
+++ b/packages/cli/src/lib/templates.test.ts
@@ -93,13 +93,23 @@ describe('resolveTemplates()', () => {
   })
 
   it('should collect validation issues without registering the bad template', async () => {
-    write('bad.md', '---\nlabel: Bad\nhint: x\n---\n# {{title}}\n\n{{oops}}\n')
+    write('bad.md', '---\nhint: x\n---\n# {{title}}\n')
     const { registry, issues } = await resolveTemplates({
       templates: [dir],
       paths: createPaths(dir),
     })
     expect(registry.has('bad')).toBe(false)
-    expect(issues.some((issue) => issue.type === 'unknown_placeholder')).toBe(true)
+    expect(issues.some((issue) => issue.type === 'missing_field')).toBe(true)
+  })
+
+  it('should register a template that uses undeclared {{ }} markers', async () => {
+    write('note.md', '---\nlabel: Note\nhint: x\n---\n# {{title}}\n\n{{ decision }} and {{ }}\n')
+    const { registry, issues } = await resolveTemplates({
+      templates: [dir],
+      paths: createPaths(dir),
+    })
+    expect(registry.has('note')).toBe(true)
+    expect(issues).toStrictEqual([])
   })
 
   it('should report an unreadable templates directory as an issue', async () => {

--- a/packages/cli/src/lib/vars.test.ts
+++ b/packages/cli/src/lib/vars.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildBuiltInVars, parseVarArgs } from './vars'
+
+describe('parseVarArgs()', () => {
+  it('should return empty results when no args are passed', () => {
+    expect(parseVarArgs(undefined)).toStrictEqual({ values: {}, invalid: [] })
+  })
+
+  it('should parse id=value pairs', () => {
+    const { values, invalid } = parseVarArgs(['decision=Use Postgres', 'status=accepted'])
+    expect(values).toStrictEqual({ decision: 'Use Postgres', status: 'accepted' })
+    expect(invalid).toStrictEqual([])
+  })
+
+  it('should split on the first = so values may contain =', () => {
+    const { values } = parseVarArgs(['expr=a=b=c'])
+    expect(values).toStrictEqual({ expr: 'a=b=c' })
+  })
+
+  it('should allow an empty value', () => {
+    const { values, invalid } = parseVarArgs(['context='])
+    expect(values).toStrictEqual({ context: '' })
+    expect(invalid).toStrictEqual([])
+  })
+
+  it('should collect entries with no = as invalid', () => {
+    const { values, invalid } = parseVarArgs(['decision'])
+    expect(values).toStrictEqual({})
+    expect(invalid).toStrictEqual(['decision'])
+  })
+
+  it('should collect entries with an empty id as invalid', () => {
+    const { invalid } = parseVarArgs(['=orphan'])
+    expect(invalid).toStrictEqual(['=orphan'])
+  })
+})
+
+describe('buildBuiltInVars()', () => {
+  it('should build title, slug, filename, and an ISO date', () => {
+    const result = buildBuiltInVars({
+      title: 'Auth',
+      slug: 'auth',
+      filename: 'auth.md',
+      now: new Date('2026-07-08T12:34:56Z'),
+    })
+    expect(result).toStrictEqual({
+      title: 'Auth',
+      slug: 'auth',
+      filename: 'auth.md',
+      date: '2026-07-08',
+    })
+  })
+})

--- a/packages/cli/src/lib/vars.ts
+++ b/packages/cli/src/lib/vars.ts
@@ -1,0 +1,115 @@
+/**
+ * Parsing helpers for `draft` template variables: the `--var id=value`
+ * arguments and the always-available built-in variables. Kept pure and free of
+ * prompts/IO so they can be unit-tested in isolation.
+ */
+
+/**
+ * Reserved built-in variable ids, always resolved by `draft` regardless of a
+ * template's declared `vars`. A template may still list one of these in `vars`
+ * (e.g. for documentation), but the built-in value wins.
+ */
+export const RESERVED_VARS = ['title', 'slug', 'date', 'filename'] as const
+
+/**
+ * The outcome of parsing `--var` arguments: the resolved key/value map plus any
+ * malformed entries (missing `=` or empty id) for the caller to warn about.
+ */
+export interface ParsedVarArgs {
+  readonly values: Readonly<Record<string, string>>
+  readonly invalid: readonly string[]
+}
+
+/**
+ * Parse repeated `--var id=value` arguments into a key/value map.
+ *
+ * Splits on the first `=` so values may themselves contain `=`. Entries with no
+ * `=` or an empty id are collected into `invalid` rather than silently dropped.
+ *
+ * @example
+ * ```ts
+ * parseVarArgs(['decision=Use Postgres', 'context=']).values
+ * // { decision: 'Use Postgres', context: '' }
+ * ```
+ *
+ * @param args - The raw `--var` argument strings, or undefined when none passed
+ * @returns The parsed values and any malformed entries
+ */
+export function parseVarArgs(args: readonly string[] | undefined): ParsedVarArgs {
+  if (args === undefined) {
+    return { values: {}, invalid: [] }
+  }
+  const parsed = args.map(parseVarArg)
+  const values = Object.fromEntries(
+    parsed.flatMap((entry) => {
+      if (entry.ok) {
+        return [[entry.id, entry.value] as const]
+      }
+      return []
+    })
+  )
+  const invalid = parsed.flatMap((entry) => {
+    if (entry.ok) {
+      return []
+    }
+    return [entry.raw]
+  })
+  return { values, invalid }
+}
+
+/**
+ * The outcome of parsing a single `--var` argument.
+ */
+type VarArgOutcome =
+  | { readonly ok: true; readonly id: string; readonly value: string }
+  | { readonly ok: false; readonly raw: string }
+
+/**
+ * Parse a single `id=value` argument, splitting on the first `=`.
+ *
+ * @private
+ * @param raw - The raw argument string
+ * @returns An `ok` outcome with id/value, or a failure carrying the raw string
+ */
+function parseVarArg(raw: string): VarArgOutcome {
+  const eq = raw.indexOf('=')
+  if (eq <= 0) {
+    return { ok: false, raw }
+  }
+  const id = raw.slice(0, eq).trim()
+  if (id.length === 0) {
+    return { ok: false, raw }
+  }
+  return { ok: true, id, value: raw.slice(eq + 1) }
+}
+
+/**
+ * Build the always-available built-in variables for a draft.
+ *
+ * @example
+ * ```ts
+ * buildBuiltInVars({
+ *   title: 'Auth',
+ *   slug: 'auth',
+ *   filename: 'auth.md',
+ *   now: new Date('2026-07-08T00:00:00Z'),
+ * })
+ * // { title: 'Auth', slug: 'auth', filename: 'auth.md', date: '2026-07-08' }
+ * ```
+ *
+ * @param input - The resolved title, slug, output filename, and current date
+ * @returns The built-in variable map (title, slug, filename, ISO date)
+ */
+export function buildBuiltInVars(input: {
+  readonly title: string
+  readonly slug: string
+  readonly filename: string
+  readonly now: Date
+}): Readonly<Record<string, string>> {
+  return {
+    title: input.title,
+    slug: input.slug,
+    filename: input.filename,
+    date: input.now.toISOString().slice(0, 10),
+  }
+}

--- a/packages/cli/src/lib/vars.ts
+++ b/packages/cli/src/lib/vars.ts
@@ -58,6 +58,16 @@ export function parseVarArgs(args: readonly string[] | undefined): ParsedVarArgs
 }
 
 /**
+ * The always-available built-in variables resolved for every draft.
+ */
+export interface BuiltInVars {
+  readonly title: string
+  readonly slug: string
+  readonly date: string
+  readonly filename: string
+}
+
+/**
  * The outcome of parsing a single `--var` argument.
  */
 type VarArgOutcome =
@@ -105,7 +115,7 @@ export function buildBuiltInVars(input: {
   readonly slug: string
   readonly filename: string
   readonly now: Date
-}): Readonly<Record<string, string>> {
+}): BuiltInVars {
   return {
     title: input.title,
     slug: input.slug,

--- a/packages/templates/src/build.test.ts
+++ b/packages/templates/src/build.test.ts
@@ -48,6 +48,59 @@ describe('buildTemplate()', () => {
     expect(template).toBeNull()
   })
 
+  it('should read declared vars from frontmatter', () => {
+    const [error, template] = buildTemplate({
+      ...validInput,
+      data: {
+        label: 'ADR',
+        hint: 'x',
+        vars: [
+          { id: 'decision', title: 'Decision', description: 'The change being made' },
+          { id: 'status' },
+        ],
+      },
+    })
+    expect(error).toBeNull()
+    expect(template).toMatchObject({
+      vars: [
+        { id: 'decision', title: 'Decision', description: 'The change being made' },
+        { id: 'status' },
+      ],
+    })
+  })
+
+  it('should omit vars when frontmatter declares none', () => {
+    const [, template] = buildTemplate(validInput)
+    expect(template).not.toHaveProperty('vars')
+  })
+
+  it('should reject vars that are not a list', () => {
+    const [error, template] = buildTemplate({
+      ...validInput,
+      data: { label: 'ADR', hint: 'x', vars: 'decision' },
+    })
+    expect(error).toMatchObject({ type: 'invalid_vars' })
+    expect(template).toBeNull()
+  })
+
+  it('should reject a var entry missing an id', () => {
+    const [error, template] = buildTemplate({
+      ...validInput,
+      data: { label: 'ADR', hint: 'x', vars: [{ title: 'No id' }] },
+    })
+    expect(error).toMatchObject({ type: 'invalid_vars' })
+    expect(template).toBeNull()
+  })
+
+  it('should allow undeclared {{ }} markers to pass through', () => {
+    const [error, template] = buildTemplate({
+      ...validInput,
+      content: '# {{title}}\n\n{{ decision }} and {{ }}\n',
+    })
+    expect(error).toBeNull()
+    expect(template).toMatchObject({ body: '# {{title}}\n\n{{ decision }} and {{ }}\n' })
+  })
+
   it('should reject a missing label', () => {
     const [error, template] = buildTemplate({ ...validInput, data: { hint: 'x' } })
     expect(error).toMatchObject({ type: 'missing_field' })
@@ -63,15 +116,6 @@ describe('buildTemplate()', () => {
   it('should reject an empty body', () => {
     const [error, template] = buildTemplate({ ...validInput, content: '   \n' })
     expect(error).toMatchObject({ type: 'empty_body' })
-    expect(template).toBeNull()
-  })
-
-  it('should reject a placeholder other than title', () => {
-    const [error, template] = buildTemplate({
-      ...validInput,
-      content: '# {{title}}\n\n{{author}}\n',
-    })
-    expect(error).toMatchObject({ type: 'unknown_placeholder' })
     expect(template).toBeNull()
   })
 

--- a/packages/templates/src/build.ts
+++ b/packages/templates/src/build.ts
@@ -1,11 +1,9 @@
-import { isString } from 'massaman/predicate'
+import { isPlainObject, isString } from 'massaman/predicate'
 
-import type { Result, Template, TemplateError, TemplateErrorType } from './types.ts'
+import type { Result, Template, TemplateError, TemplateErrorType, TemplateVar } from './types.ts'
 
 const TYPE_PATTERN = /^[a-z0-9-]+$/
-const PLACEHOLDER_PATTERN = /\{\{\s*([^}]+?)\s*\}\}/g
-const ALLOWED_FIELDS = new Set(['label', 'hint', 'group'])
-const ALLOWED_PLACEHOLDERS = new Set(['title'])
+const ALLOWED_FIELDS = new Set(['label', 'hint', 'group', 'vars'])
 
 /**
  * Input for {@link buildTemplate}: a parsed template file split into its
@@ -28,15 +26,21 @@ export interface BuildTemplateInput {
  * Validate a parsed template file and build a {@link Template}.
  *
  * Enforces the "simple prebuild markdown" contract: `type` is a kebab slug,
- * frontmatter carries only `label`/`hint`, the body is non-empty, and the only
- * supported interpolation is `{{title}}`.
+ * frontmatter carries only `label`/`hint`/`group`/`vars`, and the body is
+ * non-empty. `{{ }}` markers in the body are never rejected — declared `vars`
+ * name the fillable ones, and any undeclared marker passes through as plain
+ * text.
  *
  * @example
  * ```ts
  * const [error, template] = buildTemplate({
  *   type: 'adr',
- *   data: { label: 'ADR', hint: 'Architecture decision record' },
- *   content: '# {{title}}\n\n## Context\n',
+ *   data: {
+ *     label: 'ADR',
+ *     hint: 'Architecture decision record',
+ *     vars: [{ id: 'decision', description: 'The choice being made' }],
+ *   },
+ *   content: '# {{title}}\n\n## Decision\n{{ decision }}\n',
  *   extension: '.md',
  * })
  * ```
@@ -62,7 +66,7 @@ export function buildTemplate(input: BuildTemplateInput): Result<Template, Templ
     return [
       templateError(
         'unknown_field',
-        `Unknown frontmatter field "${unknownField}" in template "${type}" (allowed: label, hint, group)`
+        `Unknown frontmatter field "${unknownField}" in template "${type}" (allowed: label, hint, group, vars)`
       ),
       null,
     ]
@@ -83,20 +87,27 @@ export function buildTemplate(input: BuildTemplateInput): Result<Template, Templ
     return [groupError, null]
   }
 
+  const [varsError, vars] = readVars({ type, value: data.vars })
+  if (varsError) {
+    return [varsError, null]
+  }
+
   if (content.trim().length === 0) {
     return [templateError('empty_body', `Template "${type}" has an empty body`), null]
   }
 
-  const placeholderError = findUnknownPlaceholder({ type, content })
-  if (placeholderError) {
-    return [placeholderError, null]
-  }
-
   const group = frontmatterGroup ?? input.group
-  if (group === undefined) {
-    return [null, { type, label, hint, body: content, extension }]
+  const base = { type, label, hint, body: content, extension }
+  if (vars === undefined && group === undefined) {
+    return [null, base]
   }
-  return [null, { type, label, hint, body: content, extension, group }]
+  if (vars === undefined) {
+    return [null, { ...base, group }]
+  }
+  if (group === undefined) {
+    return [null, { ...base, vars }]
+  }
+  return [null, { ...base, vars, group }]
 }
 
 /**
@@ -172,27 +183,103 @@ function readOptionalGroup(input: {
 }
 
 /**
- * Scan a template body for any placeholder other than `{{title}}`.
+ * Read and validate the optional `vars` frontmatter field: absent yields
+ * `undefined`, otherwise it must be an array of entries each carrying a
+ * non-empty string `id` plus optional string `title`/`description`.
  *
  * @private
- * @param input - The template type and its body content
- * @returns An `unknown_placeholder` error for the first stray token, else null
+ * @param input - The template type and the raw `vars` value
+ * @returns A Result tuple: the parsed vars or `undefined`, or an `invalid_vars` error
  */
-function findUnknownPlaceholder(input: {
+function readVars(input: {
   readonly type: string
-  readonly content: string
-}): TemplateError | null {
-  const { type, content } = input
-  const unknown = [...content.matchAll(PLACEHOLDER_PATTERN)]
-    .map((match) => (match[1] ?? '').trim())
-    .find((name) => !ALLOWED_PLACEHOLDERS.has(name))
-  if (unknown !== undefined) {
-    return templateError(
-      'unknown_placeholder',
-      `Template "${type}" uses unknown placeholder "{{${unknown}}}" (only {{title}} is supported)`
-    )
+  readonly value: unknown
+}): Result<readonly TemplateVar[] | undefined, TemplateError> {
+  const { type, value } = input
+  if (value === undefined) {
+    return [null, undefined]
   }
-  return null
+  if (!Array.isArray(value)) {
+    return [
+      templateError('invalid_vars', `Template "${type}" has an invalid "vars" (must be a list)`),
+      null,
+    ]
+  }
+  return value.reduce<Result<readonly TemplateVar[], TemplateError>>(
+    (acc, entry, index) => {
+      const [accError, accVars] = acc
+      if (accError) {
+        return acc
+      }
+      const [entryError, parsed] = readVarEntry({ type, entry, index })
+      if (entryError) {
+        return [entryError, null]
+      }
+      return [null, [...accVars, parsed]]
+    },
+    [null, []]
+  )
+}
+
+/**
+ * Validate a single `vars` entry into a {@link TemplateVar}.
+ *
+ * @private
+ * @param input - The template type, the raw entry, and its list index
+ * @returns A Result tuple: the parsed var, or an `invalid_vars` error
+ */
+function readVarEntry(input: {
+  readonly type: string
+  readonly entry: unknown
+  readonly index: number
+}): Result<TemplateVar, TemplateError> {
+  const { type, entry, index } = input
+
+  if (!isPlainObject(entry)) {
+    return [invalidVar({ type, index, detail: 'each var must be an object with an "id"' }), null]
+  }
+  if (!isString(entry.id) || entry.id.trim().length === 0) {
+    return [
+      invalidVar({ type, index, detail: '"id" is required and must be a non-empty string' }),
+      null,
+    ]
+  }
+  if (entry.title !== undefined && !isString(entry.title)) {
+    return [invalidVar({ type, index, detail: '"title" must be a string when set' }), null]
+  }
+  if (entry.description !== undefined && !isString(entry.description)) {
+    return [invalidVar({ type, index, detail: '"description" must be a string when set' }), null]
+  }
+
+  const id = entry.id.trim()
+  if (isString(entry.title) && isString(entry.description)) {
+    return [null, { id, title: entry.title.trim(), description: entry.description.trim() }]
+  }
+  if (isString(entry.title)) {
+    return [null, { id, title: entry.title.trim() }]
+  }
+  if (isString(entry.description)) {
+    return [null, { id, description: entry.description.trim() }]
+  }
+  return [null, { id }]
+}
+
+/**
+ * Construct an `invalid_vars` {@link TemplateError} for a single bad entry.
+ *
+ * @private
+ * @param input - The template type, the entry index, and the failure detail
+ * @returns A `TemplateError` describing the malformed var
+ */
+function invalidVar(input: {
+  readonly type: string
+  readonly index: number
+  readonly detail: string
+}): TemplateError {
+  return templateError(
+    'invalid_vars',
+    `Template "${input.type}" has an invalid var at index ${input.index}: ${input.detail}`
+  )
 }
 
 /**

--- a/packages/templates/src/index.ts
+++ b/packages/templates/src/index.ts
@@ -1,6 +1,7 @@
 export type {
   Template,
   TemplateType,
+  TemplateVar,
   TemplateVariables,
   TemplateRegistry,
   ExtendTemplateOptions,
@@ -19,4 +20,4 @@ export { defineTemplate } from './define.ts'
 export { buildTemplate } from './build.ts'
 export type { BuildTemplateInput } from './build.ts'
 
-export { render, toSlug } from './render.ts'
+export { render, toSlug, findMarkers } from './render.ts'

--- a/packages/templates/src/render.test.ts
+++ b/packages/templates/src/render.test.ts
@@ -84,6 +84,21 @@ describe('findMarkers()', () => {
   it('should return an empty array when no markers remain', () => {
     expect(findMarkers('nothing to fill here')).toStrictEqual([])
   })
+
+  it('should ignore JSX/MDX inline objects like style={{ ... }}', () => {
+    const jsx = "<span style={{ display: 'inline-flex', color: '#34d399' }} />"
+    expect(findMarkers(jsx)).toStrictEqual([])
+  })
+
+  it('should not substitute a JSX inline object as if it were a marker', () => {
+    const template: Template = {
+      type: 'test',
+      label: 'Test',
+      hint: 'test',
+      body: "<span style={{ color: 'red' }}>{{ title }}</span>",
+    }
+    expect(render(template, { title: 'Auth' })).toBe("<span style={{ color: 'red' }}>Auth</span>")
+  })
 })
 
 describe('toSlug()', () => {

--- a/packages/templates/src/render.test.ts
+++ b/packages/templates/src/render.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { render, toSlug } from './render'
+import { findMarkers, render, toSlug } from './render'
 import type { Template } from './types'
 
 const MOCK_TEMPLATE: Template = {
@@ -46,6 +46,43 @@ describe('render()', () => {
   it('should handle titles with special characters', () => {
     const result = render(MOCK_TEMPLATE, { title: 'OAuth 2.0 & OIDC' })
     expect(result).toContain('# OAuth 2.0 & OIDC')
+  })
+
+  it('should substitute markers regardless of interior whitespace', () => {
+    const template: Template = {
+      type: 'test',
+      label: 'Test',
+      hint: 'test',
+      body: '{{title}} — {{ title }} — {{  title  }}',
+    }
+    const result = render(template, { title: 'Auth' })
+    expect(result).toBe('Auth — Auth — Auth')
+  })
+
+  it('should leave an unfilled declared marker untouched', () => {
+    const template: Template = {
+      type: 'test',
+      label: 'Test',
+      hint: 'test',
+      body: '# {{title}}\n\n{{ decision }}',
+    }
+    const result = render(template, { title: 'Auth' })
+    expect(result).toBe('# Auth\n\n{{ decision }}')
+  })
+})
+
+describe('findMarkers()', () => {
+  it('should list distinct markers normalized to {{ key }}', () => {
+    const result = findMarkers('{{ decision }} and {{decision}} and {{ context }}')
+    expect(result).toStrictEqual(['{{ decision }}', '{{ context }}'])
+  })
+
+  it('should normalize an empty marker to {{ }}', () => {
+    expect(findMarkers('fill {{ }} here')).toStrictEqual(['{{ }}'])
+  })
+
+  it('should return an empty array when no markers remain', () => {
+    expect(findMarkers('nothing to fill here')).toStrictEqual([])
   })
 })
 

--- a/packages/templates/src/render.ts
+++ b/packages/templates/src/render.ts
@@ -2,24 +2,59 @@ import { kebabCase } from 'massaman/string'
 
 import type { Template, TemplateVariables } from './types.ts'
 
+// Matches a `{{ key }}` marker, tolerating any interior whitespace and
+// capturing the trimmed key. The empty-marker form `{{ }}` matches with an
+// empty capture. Global so a single pass covers every marker in the body.
+const MARKER_PATTERN = /\{\{\s*([^}]*?)\s*\}\}/g
+
 /**
- * Render a template by replacing all `{{key}}` placeholders with
- * the corresponding values from the variables map.
+ * Render a template by replacing every `{{ key }}` marker whose key appears in
+ * `variables` with its value. Interior whitespace is tolerated, so `{{title}}`
+ * and `{{ title }}` are equivalent. Markers whose key is absent from
+ * `variables` are left untouched — the raw marker passes through for a human or
+ * agent to fill in later.
  *
  * @example
  * ```ts
  * const output = render(template, { title: 'Authentication' })
  * ```
  *
- * @param template - The template whose body contains `{{key}}` placeholders
- * @param variables - Key/value map used to replace each placeholder
- * @returns The rendered string with all placeholders substituted
+ * @param template - The template whose body contains `{{ key }}` markers
+ * @param variables - Key/value map used to replace each matching marker
+ * @returns The rendered string with matching markers substituted
  */
 export function render(template: Template, variables: TemplateVariables): string {
-  return Object.entries(variables).reduce(
-    (result, [key, value]) => result.replaceAll(`{{${key}}}`, value),
-    template.body
-  )
+  return template.body.replaceAll(MARKER_PATTERN, (marker, rawKey: string) => {
+    const key = rawKey.trim()
+    if (Object.hasOwn(variables, key)) {
+      return variables[key]
+    }
+    return marker
+  })
+}
+
+/**
+ * List the distinct `{{ ... }}` markers remaining in a string, in first-seen
+ * order. Used to build the post-draft "still to fill" checklist and to detect
+ * leftover markers in published docs.
+ *
+ * @example
+ * ```ts
+ * findMarkers('{{ decision }} and {{ decision }}') // ['{{ decision }}']
+ * ```
+ *
+ * @param text - The rendered document text to scan
+ * @returns The unique marker strings, each normalized to `{{ key }}`
+ */
+export function findMarkers(text: string): readonly string[] {
+  const normalized = [...text.matchAll(MARKER_PATTERN)].map((match) => {
+    const key = (match[1] ?? '').trim()
+    if (key.length === 0) {
+      return '{{ }}'
+    }
+    return `{{ ${key} }}`
+  })
+  return [...new Set(normalized)]
 }
 
 /**

--- a/packages/templates/src/render.ts
+++ b/packages/templates/src/render.ts
@@ -2,10 +2,13 @@ import { kebabCase } from 'massaman/string'
 
 import type { Template, TemplateVariables } from './types.ts'
 
-// Matches a `{{ key }}` marker, tolerating any interior whitespace and
+// Matches a `{{ key }}` fill marker, tolerating any interior whitespace and
 // capturing the trimmed key. The empty-marker form `{{ }}` matches with an
-// empty capture. Global so a single pass covers every marker in the body.
-const MARKER_PATTERN = /\{\{\s*([^}]*?)\s*\}\}/g
+// empty capture. The key is deliberately limited to identifier/phrase
+// characters (word chars, spaces, hyphens, dots) so JSX/MDX inline objects
+// like `style={{ color: 'red' }}` — which carry `:`, quotes, and commas — are
+// never mistaken for markers. Global so a single pass covers the whole body.
+const MARKER_PATTERN = /\{\{\s*([\w .-]*?)\s*\}\}/g
 
 /**
  * Render a template by replacing every `{{ key }}` marker whose key appears in

--- a/packages/templates/src/types.ts
+++ b/packages/templates/src/types.ts
@@ -36,6 +36,23 @@ export interface TemplateVariables {
 }
 
 /**
+ * A fillable variable a template declares in its frontmatter under `vars`.
+ *
+ * Declared vars are the `{{ id }}` markers a `draft` fills — from `--var`
+ * arguments or an interactive prompt — leaving any it can't resolve as the raw
+ * marker for a human or agent to complete later. `title` and `description` are
+ * surfaced as the prompt label and hint. Only `id` is required.
+ */
+export interface TemplateVar {
+  /** The placeholder id: the token inside `{{ }}` (e.g. `decision`). */
+  readonly id: string
+  /** Human-readable label shown when prompting for this var. */
+  readonly title?: string
+  /** Guidance shown alongside the prompt describing what to fill in. */
+  readonly description?: string
+}
+
+/**
  * A documentation template definition.
  */
 export interface Template {
@@ -43,6 +60,12 @@ export interface Template {
   readonly label: string
   readonly hint: string
   readonly body: string
+  /**
+   * Fillable variables declared in the template's `vars` frontmatter. Absent
+   * when the template declares none; undeclared `{{ }}` markers in the body are
+   * always allowed and pass through as plain text.
+   */
+  readonly vars?: readonly TemplateVar[]
   /**
    * Output file extension used when scaffolding a document from this template.
    * Defaults to `.md`; `.mdx` routes the drafted file through the MDX pipeline.
@@ -63,7 +86,7 @@ export type TemplateErrorType =
   | 'missing_field'
   | 'unknown_field'
   | 'invalid_type'
-  | 'unknown_placeholder'
+  | 'invalid_vars'
   | 'empty_body'
   | 'invalid_group'
 


### PR DESCRIPTION
## Summary

Turns the `{{ }}` fill convention into a first-class feature and unblocks registered templates that use it. Addresses #150 (the blocker) and lands the core of #148.

- Templates declare fillable variables in frontmatter under `vars`.
- `ciderpress draft` fills them from `--var id=value` args, prompts for the rest on a TTY, and leaves anything unfilled as a raw `{{ id }}` marker — so a coding agent can complete it afterward. It prints a checklist of what remains.
- Built-in variables `{{title}}`, `{{slug}}`, `{{date}}`, `{{filename}}` are always substituted.
- **Undeclared** `{{ }}` markers pass through as plain text — never an error (fixes #150).
- New lint: `ciderpress check` / `build --check` fail when a **published** doc still contains a `{{ }}` marker (fenced/inline code excluded so doc examples don't false-positive).

## Changes

**`@ciderpress/templates`**
- `Template` gains optional `vars: TemplateVar[]` (each `{ id, title?, description? }`, only `id` required).
- `buildTemplate` validates `vars`, allows `vars` frontmatter, and no longer emits `unknown_placeholder` — replaced by `invalid_vars`. Any `{{ }}` marker in a body is now allowed.
- `render` tolerates interior whitespace (`{{ title }}` === `{{title}}`) and leaves unmatched markers untouched.
- New `findMarkers()` export lists remaining markers.

**`@ciderpress/cli`**
- `draft` gains repeatable `--var id=value`, built-in var substitution, TTY prompting for declared vars (blank = leave marker), and an unfilled-marker checklist.
- New `lib/markers.ts` scans synced content; wired into `check` and `build --check` via `runMarkersCheck`.

**Docs / examples**
- `docs/framework/templates.md` + `docs/references/cli.md` document the variable model and lint.
- `examples/simple/.templates/adr.md` updated to demonstrate declared vars, a built-in (`{{date}}`), and undeclared passthrough markers.

## Testing

- `pnpm check` green (typecheck + lint + format).
- New/updated unit tests: `build.test.ts` (vars validation, marker passthrough), `render.test.ts` (whitespace tolerance, `findMarkers`), `vars.test.ts` (`--var` parsing, built-ins), `markers.test.ts` (leftover-marker scan incl. code-fence exclusion), `check.test.ts` (marker-failure verdict). Templates 58 tests, CLI 224 tests passing.
- Manually verified end-to-end against `examples/simple`: `draft --type adr --var decision=...` fills `decision`, auto-fills `{{date}}`, and leaves `{{ consequences }}`/`{{ status }}`/`{{ context }}` as raw markers with a checklist; `templates check` reports all 10 templates valid.

## Related Issues

Closes #150 · advances #148