### PR TITLE
feat(packages/config,packages/cli): source group card descriptions from overview pages

### DIFF
--- a/.changeset/group-card-descriptions.md
+++ b/.changeset/group-card-descriptions.md
@@ -1,0 +1,26 @@
+---
+'@ciderpress/cli': minor
+'@ciderpress/config': minor
+---
+
+Auto-source group card and landing descriptions from an overview page.
+
+An auto-generated group landing now populates each nested group's card
+description (and the group's own landing intro) from that group's
+overview/root page — `overview.md`, `index.md`, `readme.md`, … — instead
+of leaving it blank. Previously only an explicit config `description`
+reached a nested group card, so auto-discovered groups rendered
+description-less cards even when a root page existed.
+
+Resolution precedence (highest first): `card.description` →
+`Page.description` → the group's overview page frontmatter `description` →
+that overview's first paragraph.
+
+- **`@ciderpress/config`** — new `discover.descriptionFallback:
+  'firstParagraph' | 'none'` field on `Page.discover`, `Workspace.discover`,
+  and the top-level `discover`. Defaults to `'firstParagraph'`; set `'none'`
+  to require an explicit frontmatter `description` and skip first-paragraph
+  inference. A new `DescriptionFallback` type is exported.
+- **`@ciderpress/cli`** — group descriptions are resolved once in the sync
+  resolve layer and reused for both the parent card and the group's landing.
+  Section cards now honor `card.description`, matching workspace cards.

--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -203,6 +203,7 @@ interface Page {
     recursive?: boolean
     ignore?: string[]
     indexFile?: string
+    descriptionFallback?: 'firstParagraph' | 'none'
   }
 
   // ---- Per-page integration ----
@@ -265,7 +266,7 @@ interface CardConfig {
 | `tags`        | `string[]`                     | Tag chips rendered below the description                                                    |
 | `badge`       | `{ src: string; alt: string }` | Logo badge rendered in the card's top-right corner                                          |
 
-Card content resolves from this priority order (highest first): `card.description` → source file frontmatter `description` → `Page.description`.
+Card content resolves from this priority order (highest first): `card.description` → `Page.description` → the group's overview/root page (`overview.md`, `index.md`, `readme.md`, …) frontmatter `description` → that overview's first paragraph. This means a nested group card is populated automatically from its overview page — no need to restate the description in config. Set `discover.descriptionFallback: 'none'` to require an explicit frontmatter `description` and skip the first-paragraph inference.
 
 #### `defaults` — default page metadata
 
@@ -292,6 +293,7 @@ Only applies when `include` is a glob. Renamed from the flat `Section.{sort,recu
 | `discover.recursive` | `boolean`      | `true`       | Recurse into subdirectories                                                                                |
 | `discover.ignore`    | `string[]`     | —            | Glob patterns ignored during discovery (renamed from `exclude` — gitignore vocab)                          |
 | `discover.indexFile` | `string`       | `'overview'` | Filename treated as the page's own content instead of generating a landing page (renamed from `entryFile`) |
+| `discover.descriptionFallback` | `'firstParagraph' \| 'none'` | `'firstParagraph'` | How to source a group's card/landing description when its overview file has no frontmatter `description`. `'none'` requires an explicit `description`. Overrides the top-level `discover.descriptionFallback` |
 
 #### `openapi`
 
@@ -369,6 +371,7 @@ interface Workspace {
     recursive?: boolean
     ignore?: string[]
     indexFile?: string
+    descriptionFallback?: 'firstParagraph' | 'none'
   }
   openapi?: OpenAPISpec
 }
@@ -1058,17 +1061,19 @@ home: {
 
 ## `discover`
 
-Top-level cross-cutting discovery options. Only field is `ignore` — global glob patterns excluded from every page's auto-discovery.
+Top-level cross-cutting discovery options.
 
 ```ts
 discover?: {
   ignore?: string[],
+  descriptionFallback?: 'firstParagraph' | 'none',
 }
 ```
 
-| Field             | Type       | Description                                                          |
-| ----------------- | ---------- | -------------------------------------------------------------------- |
-| `discover.ignore` | `string[]` | Glob patterns excluded from every page's discovery (gitignore vocab) |
+| Field                          | Type                         | Description                                                                                                                                       |
+| ------------------------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `discover.ignore`              | `string[]`                   | Glob patterns excluded from every page's discovery (gitignore vocab)                                                                              |
+| `discover.descriptionFallback` | `'firstParagraph' \| 'none'` | Default strategy for sourcing a group's card/landing description when its overview file has no frontmatter `description`. Default `'firstParagraph'` |
 
 ```ts
 discover: {

--- a/packages/cli/src/lib/sync/index.ts
+++ b/packages/cli/src/lib/sync/index.ts
@@ -136,7 +136,14 @@ export async function sync(config: CiderpressConfig, options: SyncOptions): Prom
 
   // Returns a new tree (immutable) rather than mutating `enriched`.
   const workspaces = collectAllWorkspaceItems(config)
-  const withLandings = injectLandingPages(enriched, rootPages, workspaces)
+  const descriptionFallback = match(config.discover)
+    .with(P.nonNullable, (d) => d.descriptionFallback)
+    .otherwise(() => undefined)
+  const withLandings = injectLandingPages(
+    enriched,
+    workspaces,
+    descriptionFallback ?? 'firstParagraph'
+  )
 
   // Stamp badges (frontmatter/defaults/glob + named statuses) onto the
   // tree so `_meta.json` generation can carry them as Rspress `tag`s, and

--- a/packages/cli/src/lib/sync/resolve/description.test.ts
+++ b/packages/cli/src/lib/sync/resolve/description.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import type { ResolvedEntry } from '../types'
+
+const { readFile } = vi.hoisted(() => ({ readFile: vi.fn<(p: string) => Promise<string>>() }))
+
+vi.mock(import('node:fs/promises'), () => ({ default: { readFile } }))
+vi.mock(import('node:fs'), () => ({ existsSync: vi.fn(() => false) }))
+
+const { extractFileDescription, findEntrySlugChild, resolveGroupDescription } =
+  await import('./description')
+
+describe('extractFileDescription()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should prefer the frontmatter description', async () => {
+    readFile.mockResolvedValue('---\ndescription: From frontmatter\n---\n# Title\n\nProse here.\n')
+    const result = await extractFileDescription('/docs/overview.md', 'firstParagraph')
+    expect(result).toBe('From frontmatter')
+  })
+
+  it('should fall back to the first paragraph after the heading', async () => {
+    readFile.mockResolvedValue('# Title\n\nThe intro paragraph.\n\nSecond paragraph.\n')
+    const result = await extractFileDescription('/docs/overview.md', 'firstParagraph')
+    expect(result).toBe('The intro paragraph.')
+  })
+
+  it('should return undefined for the none fallback when no frontmatter description', async () => {
+    readFile.mockResolvedValue('# Title\n\nThe intro paragraph.\n')
+    const result = await extractFileDescription('/docs/overview.md', 'none')
+    expect(result).toBeUndefined()
+  })
+
+  it('should still use the frontmatter description under the none fallback', async () => {
+    readFile.mockResolvedValue('---\ndescription: Explicit\n---\n# Title\n\nProse.\n')
+    const result = await extractFileDescription('/docs/overview.md', 'none')
+    expect(result).toBe('Explicit')
+  })
+
+  it('should return undefined when the file cannot be read', async () => {
+    readFile.mockRejectedValue(new Error('ENOENT'))
+    const result = await extractFileDescription('/missing.md', 'firstParagraph')
+    expect(result).toBeUndefined()
+  })
+})
+
+describe('findEntrySlugChild()', () => {
+  it('should select the entry-slug child with a source file', () => {
+    const overview: ResolvedEntry = {
+      title: 'Overview',
+      link: '/group/overview',
+      page: { source: '/abs/group/overview.md', outputPath: 'group/overview.md', frontmatter: {} },
+    }
+    const other: ResolvedEntry = {
+      title: 'Details',
+      link: '/group/details',
+      page: { source: '/abs/group/details.md', outputPath: 'group/details.md', frontmatter: {} },
+    }
+    expect(findEntrySlugChild([other, overview])).toBe(overview)
+  })
+
+  it('should prefer higher-priority entry slugs (introduction over readme)', () => {
+    const readme: ResolvedEntry = {
+      title: 'Readme',
+      link: '/group/readme',
+      page: { source: '/abs/group/readme.md', outputPath: 'group/readme.md', frontmatter: {} },
+    }
+    const intro: ResolvedEntry = {
+      title: 'Introduction',
+      link: '/group/introduction',
+      page: {
+        source: '/abs/group/introduction.md',
+        outputPath: 'group/introduction.md',
+        frontmatter: {},
+      },
+    }
+    expect(findEntrySlugChild([readme, intro])).toBe(intro)
+  })
+
+  it('should return undefined when no child is an entry slug', () => {
+    const leaf: ResolvedEntry = {
+      title: 'Leaf',
+      link: '/group/leaf',
+      page: { source: '/abs/group/leaf.md', outputPath: 'group/leaf.md', frontmatter: {} },
+    }
+    expect(findEntrySlugChild([leaf])).toBeUndefined()
+  })
+
+  it('should ignore entry-slug children without a source file', () => {
+    const virtualOverview: ResolvedEntry = {
+      title: 'Overview',
+      link: '/group/overview',
+      page: { outputPath: 'group/overview.mdx', frontmatter: {} },
+    }
+    expect(findEntrySlugChild([virtualOverview])).toBeUndefined()
+  })
+})
+
+describe('resolveGroupDescription()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return the explicit config description without reading files', async () => {
+    const result = await resolveGroupDescription({
+      explicit: 'Config wins',
+      sourcePath: '/abs/overview.md',
+      children: [],
+      fallback: 'firstParagraph',
+    })
+    expect(result).toBe('Config wins')
+    expect(readFile).not.toHaveBeenCalled()
+  })
+
+  it('should read the group overview page when there is no explicit description', async () => {
+    readFile.mockResolvedValue('---\ndescription: From overview\n---\n# Group\n')
+    const result = await resolveGroupDescription({
+      sourcePath: '/abs/group/overview.md',
+      children: [],
+      fallback: 'firstParagraph',
+    })
+    expect(result).toBe('From overview')
+  })
+
+  it('should fall back to an entry-slug child when the group has no source page', async () => {
+    readFile.mockResolvedValue('---\ndescription: From child overview\n---\n# Group\n')
+    const overview: ResolvedEntry = {
+      title: 'Overview',
+      link: '/group/overview',
+      page: { source: '/abs/group/overview.md', outputPath: 'group/overview.md', frontmatter: {} },
+    }
+    const result = await resolveGroupDescription({
+      children: [overview],
+      fallback: 'firstParagraph',
+    })
+    expect(result).toBe('From child overview')
+  })
+
+  it('should return undefined when nothing yields a description', async () => {
+    const result = await resolveGroupDescription({
+      children: [],
+      fallback: 'firstParagraph',
+    })
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/cli/src/lib/sync/resolve/description.ts
+++ b/packages/cli/src/lib/sync/resolve/description.ts
@@ -1,0 +1,268 @@
+import { existsSync } from 'node:fs'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import type { DescriptionFallback } from '@ciderpress/config'
+import { match, P } from 'massaman/match'
+import { isNil, isNotNil } from 'massaman/predicate'
+
+import { parse as parseFrontmatter } from '../frontmatter.ts'
+import type { ResolvedEntry } from '../types.ts'
+import { ENTRY_SLUGS, entrySlugRank } from './path.ts'
+
+/**
+ * Source-file extensions probed when looking for a group's overview file
+ * inside a directory, in preference order (`.md` before `.mdx`).
+ *
+ * @private
+ */
+const OVERVIEW_EXTENSIONS = ['.md', '.mdx'] as const
+
+/**
+ * Extract a short description from a markdown/MDX file.
+ *
+ * Checks frontmatter `description` first. When absent and `fallback` is
+ * `'firstParagraph'`, uses the first prose paragraph after the heading;
+ * when `'none'`, yields `undefined`. Read failures resolve to `undefined`
+ * rather than propagating.
+ *
+ * @param sourcePath - Absolute path to the source file
+ * @param fallback - Strategy when no frontmatter `description` is present
+ * @returns Description string, or undefined if none found
+ */
+export async function extractFileDescription(
+  sourcePath: string,
+  fallback: DescriptionFallback
+): Promise<string | undefined> {
+  const [readErr, raw] = await readFileSafe(sourcePath)
+  if (readErr) {
+    return undefined
+  }
+
+  const { data, content } = parseFrontmatter(raw)
+  if (isNotNil(data.description)) {
+    const fromFrontmatter = String(data.description)
+    if (fromFrontmatter.length > 0) {
+      return fromFrontmatter
+    }
+  }
+
+  if (fallback === 'none') {
+    return undefined
+  }
+
+  return extractFirstParagraph(content)
+}
+
+/**
+ * Pick the best-ranked entry-slug leaf among a group's children.
+ *
+ * Used to source a group's description from an in-group overview page
+ * (e.g. `overview.md`, `index.md`) that was discovered as a leaf child
+ * rather than promoted to the group's own page.
+ *
+ * @param items - A group's resolved child entries
+ * @returns The highest-priority entry-slug child with a source file, or undefined
+ */
+export function findEntrySlugChild(items: readonly ResolvedEntry[]): ResolvedEntry | undefined {
+  const ranked = items.flatMap((item) => {
+    if (isNil(item.link) || isNil(item.page) || isNil(item.page.source)) {
+      return []
+    }
+    const slug = item.link.split('/').findLast(Boolean) ?? ''
+    const rank = entrySlugRank(slug)
+    if (rank === -1) {
+      return []
+    }
+    return [{ item, rank }]
+  })
+
+  if (ranked.length === 0) {
+    return undefined
+  }
+
+  return ranked.reduce((best, cur) => {
+    if (cur.rank < best.rank) {
+      return cur
+    }
+    return best
+  }).item
+}
+
+/**
+ * Parameters for {@link resolveGroupDescription}.
+ */
+export interface ResolveGroupDescriptionParams {
+  /**
+   * Explicit config description (`Page.description`) — wins over any
+   * file-derived description when present.
+   */
+  readonly explicit?: string
+  /**
+   * Absolute path to the group's own overview page source, when it has one.
+   */
+  readonly sourcePath?: string
+  /**
+   * The group's resolved children — scanned for an entry-slug overview leaf.
+   */
+  readonly children: readonly ResolvedEntry[]
+  /**
+   * Absolute directory to probe for an overview file when neither
+   * `sourcePath` nor an entry-slug child yields a description.
+   */
+  readonly probeDir?: string
+  /**
+   * Preferred overview filename stem (from `discover.indexFile`).
+   */
+  readonly indexFile?: string
+  /**
+   * Strategy when a resolved file has no frontmatter `description`.
+   */
+  readonly fallback: DescriptionFallback
+}
+
+/**
+ * Resolve the description for a group (a section with children).
+ *
+ * Precedence: explicit config `description` > the group's own overview
+ * page > an entry-slug overview leaf among children > an overview file
+ * probed in `probeDir`. Returns `undefined` when nothing yields text.
+ *
+ * @param params - Resolution inputs (see {@link ResolveGroupDescriptionParams})
+ * @returns The resolved group description, or undefined
+ */
+export async function resolveGroupDescription(
+  params: ResolveGroupDescriptionParams
+): Promise<string | undefined> {
+  if (isNotNil(params.explicit)) {
+    return params.explicit
+  }
+
+  if (isNotNil(params.sourcePath)) {
+    const fromSource = await extractFileDescription(params.sourcePath, params.fallback)
+    if (isNotNil(fromSource)) {
+      return fromSource
+    }
+  }
+
+  const child = findEntrySlugChild(params.children)
+  if (isNotNil(child) && isNotNil(child.page) && isNotNil(child.page.source)) {
+    const fromChild = await extractFileDescription(child.page.source, params.fallback)
+    if (isNotNil(fromChild)) {
+      return fromChild
+    }
+  }
+
+  if (isNotNil(params.probeDir)) {
+    const overview = findOverviewFile(params.probeDir, params.indexFile)
+    if (isNotNil(overview)) {
+      return extractFileDescription(overview, params.fallback)
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Locate an overview file inside a directory by probing entry-slug names.
+ *
+ * Prefers `indexFile` (when supplied) over the built-in {@link ENTRY_SLUGS}
+ * chain, and `.md` over `.mdx` for each candidate name.
+ *
+ * @private
+ * @param dir - Absolute directory to probe
+ * @param indexFile - Preferred overview filename stem, if configured
+ * @returns Absolute path to the first existing overview file, or undefined
+ */
+function findOverviewFile(dir: string, indexFile: string | undefined): string | undefined {
+  const names = match(indexFile)
+    .with(P.string, (name) => [name, ...ENTRY_SLUGS])
+    .otherwise(() => [...ENTRY_SLUGS])
+
+  const candidates = names.flatMap((name) =>
+    OVERVIEW_EXTENSIONS.map((ext) => path.join(dir, `${name}${ext}`))
+  )
+
+  return candidates.find((candidate) => existsSync(candidate))
+}
+
+/**
+ * Extract the first non-empty prose paragraph after the first heading.
+ *
+ * Skips HTML/JSX blocks and horizontal rules, and stops at the next
+ * heading or the first blank line following collected text.
+ *
+ * @private
+ * @param content - Markdown body (frontmatter already stripped)
+ * @returns The joined paragraph text, or undefined when none is found
+ */
+function extractFirstParagraph(content: string): string | undefined {
+  const lines = content.split('\n')
+  const headingIdx = lines.findIndex((l) => l.startsWith('#'))
+  const para = resolveParagraph(lines, headingIdx)
+
+  if (para.length > 0) {
+    return para.join(' ')
+  }
+
+  return undefined
+}
+
+/**
+ * Collect the first non-empty paragraph after a heading from markdown lines.
+ *
+ * @private
+ * @param lines - Array of markdown lines
+ * @param headingIdx - Index of the heading line (-1 if none found)
+ * @returns Array of trimmed paragraph lines
+ */
+function resolveParagraph(lines: readonly string[], headingIdx: number): readonly string[] {
+  if (headingIdx === -1) {
+    return []
+  }
+
+  return lines
+    .slice(headingIdx + 1)
+    .reduce<{ readonly done: boolean; readonly result: readonly string[] }>(
+      (acc, line) => {
+        if (acc.done) {
+          return acc
+        }
+        if (line.startsWith('#')) {
+          return { done: true, result: acc.result }
+        }
+
+        const trimmed = line.trim()
+        if (trimmed === '' && acc.result.length > 0) {
+          return { done: true, result: acc.result }
+        }
+        if (trimmed === '') {
+          return acc
+        }
+        if (trimmed.startsWith('<') || trimmed.startsWith('---')) {
+          return acc
+        }
+
+        return { done: false, result: [...acc.result, trimmed] }
+      },
+      { done: false, result: [] }
+    ).result
+}
+
+/**
+ * Read a file as UTF-8, returning a Result tuple instead of throwing.
+ *
+ * @private
+ * @param sourcePath - Absolute path to the file
+ * @returns `[null, contents]` on success, `[error, null]` on failure
+ */
+async function readFileSafe(
+  sourcePath: string
+): Promise<readonly [Error, null] | readonly [null, string]> {
+  try {
+    const raw = await fs.readFile(sourcePath, 'utf8')
+    return [null, raw]
+  } catch (error) {
+    return [error as Error, null]
+  }
+}

--- a/packages/cli/src/lib/sync/resolve/index.ts
+++ b/packages/cli/src/lib/sync/resolve/index.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 import { hasAnyGlobInclude, isSingleFileInclude, normalizeInclude } from '@ciderpress/config'
-import type { Page, Frontmatter } from '@ciderpress/config'
+import type { DescriptionFallback, Page, Frontmatter } from '@ciderpress/config'
 import { log } from '@clack/prompts'
 import fg from 'fast-glob'
 import { match, P } from 'massaman/match'
@@ -12,6 +12,7 @@ import { excludeGlobbedAgentFiles } from '../agent-files.ts'
 import { syncError, collectResults } from '../errors.ts'
 import type { SyncError, SyncOutcome } from '../errors.ts'
 import type { ResolvedEntry, SyncContext } from '../types.ts'
+import { resolveGroupDescription } from './description.ts'
 import { extractBaseDir, linkToOutputPath, sourceExt } from './path.ts'
 import { resolveRecursiveGlob } from './recursive.ts'
 import { sortEntries } from './sort.ts'
@@ -248,11 +249,26 @@ async function resolveNestedSection(
   const link = section.path ?? derivedLink
   const autoLink = !section.path && link !== undefined
 
+  // Source a group description from config, its overview page, an
+  // entry-slug overview child, or a probed overview file — so nested
+  // group cards and this group's landing intro aren't left blank.
+  const sectionSource = match(sectionPage)
+    .with(P.nonNullable, (p) => p.source)
+    .otherwise(() => undefined)
+  const description = await resolveGroupDescription({
+    explicit: section.description,
+    sourcePath: sectionSource,
+    children: sorted,
+    probeDir: resolveProbeDir(ctx, section),
+    indexFile: resolveIndexFile(section),
+    fallback: resolveDescriptionFallback(ctx, section),
+  })
+
   return [
     null,
     {
       title: resolveSectionTitle(section),
-      description: section.description,
+      description,
       link,
       collapsible,
       hidden,
@@ -265,6 +281,64 @@ async function resolveNestedSection(
       page: sectionPage,
     },
   ]
+}
+
+/**
+ * Resolve the effective description fallback for a section — a per-section
+ * `discover.descriptionFallback` wins over the global `discover.descriptionFallback`,
+ * which defaults to `'firstParagraph'`.
+ *
+ * @private
+ * @param ctx - Sync context (provides global config)
+ * @param section - Page config node
+ * @returns The description fallback strategy to apply for this section
+ */
+function resolveDescriptionFallback(ctx: SyncContext, section: Page): DescriptionFallback {
+  const sectionFallback = match(section.discover)
+    .with(P.nonNullable, (d) => d.descriptionFallback)
+    .otherwise(() => undefined)
+  if (isNotNil(sectionFallback)) {
+    return sectionFallback
+  }
+  const globalFallback = match(ctx.config.discover)
+    .with(P.nonNullable, (d) => d.descriptionFallback)
+    .otherwise(() => undefined)
+  return globalFallback ?? 'firstParagraph'
+}
+
+/**
+ * Resolve the configured `discover.indexFile` for a section, if any.
+ *
+ * @private
+ * @param section - Page config node
+ * @returns The index filename stem, or undefined
+ */
+function resolveIndexFile(section: Page): string | undefined {
+  return match(section.discover)
+    .with(P.nonNullable, (d) => d.indexFile)
+    .otherwise(() => undefined)
+}
+
+/**
+ * Resolve the absolute directory to probe for an overview file when a
+ * group has a glob `include` — the static base of its first glob pattern.
+ * Returns undefined for non-glob sections (single-file includes already
+ * expose their source page).
+ *
+ * @private
+ * @param ctx - Sync context (provides repo root)
+ * @param section - Page config node
+ * @returns Absolute probe directory, or undefined
+ */
+function resolveProbeDir(ctx: SyncContext, section: Page): string | undefined {
+  if (!hasAnyGlobInclude(section.include)) {
+    return undefined
+  }
+  const patterns = normalizeInclude(section.include)
+  if (patterns.length === 0) {
+    return undefined
+  }
+  return path.resolve(ctx.repoRoot, extractBaseDir(patterns[0]))
 }
 
 /**

--- a/packages/cli/src/lib/sync/resolve/recursive.ts
+++ b/packages/cli/src/lib/sync/resolve/recursive.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 
 import { normalizeInclude } from '@ciderpress/config'
-import type { Page, Frontmatter, SortStrategy } from '@ciderpress/config'
+import type { DescriptionFallback, Page, Frontmatter, SortStrategy } from '@ciderpress/config'
 import { log } from '@clack/prompts'
 import fg from 'fast-glob'
 import { match, P } from 'massaman/match'
@@ -9,6 +9,7 @@ import { isNotNil } from 'massaman/predicate'
 
 import { excludeGlobbedAgentFiles } from '../agent-files.ts'
 import type { ResolvedEntry, SyncContext } from '../types.ts'
+import { resolveGroupDescription } from './description.ts'
 import { extractBaseDir, linkToOutputPath, sourceExt } from './path.ts'
 import { sortEntries } from './sort.ts'
 import { deriveText, kebabToTitle, resolveSectionTitle } from './text.ts'
@@ -48,6 +49,7 @@ export async function resolveRecursiveGlob(
     .with(P.nonNullable, (n) => n.collapsible)
     .otherwise(() => undefined)
   const entryFile = indexFile ?? 'overview'
+  const descriptionFallback = resolveDescriptionFallback(ctx, section)
 
   const patterns = normalizeInclude(section.include)
   if (patterns.length === 0) {
@@ -102,10 +104,34 @@ export async function resolveRecursiveGlob(
     sort,
     collapsible,
     entryFile,
+    descriptionFallback,
     ctx,
     frontmatter,
     depth,
   })
+}
+
+/**
+ * Resolve the effective description fallback for a recursive section — a
+ * per-section `discover.descriptionFallback` wins over the global one,
+ * which defaults to `'firstParagraph'`.
+ *
+ * @private
+ * @param ctx - Sync context (provides global config)
+ * @param section - Page config node
+ * @returns The description fallback strategy to apply
+ */
+function resolveDescriptionFallback(ctx: SyncContext, section: Page): DescriptionFallback {
+  const sectionFallback = match(section.discover)
+    .with(P.nonNullable, (d) => d.descriptionFallback)
+    .otherwise(() => undefined)
+  if (isNotNil(sectionFallback)) {
+    return sectionFallback
+  }
+  const globalFallback = match(ctx.config.discover)
+    .with(P.nonNullable, (d) => d.descriptionFallback)
+    .otherwise(() => undefined)
+  return globalFallback ?? 'firstParagraph'
 }
 
 /**
@@ -186,6 +212,7 @@ interface BuildEntryTreeParams {
   readonly sort: SortStrategy | undefined
   readonly collapsible: boolean | undefined
   readonly entryFile: string
+  readonly descriptionFallback: DescriptionFallback
   readonly ctx: SyncContext
   readonly frontmatter: Frontmatter
   readonly depth: number
@@ -210,6 +237,7 @@ async function buildEntryTree(params: BuildEntryTreeParams): Promise<ResolvedEnt
     sort,
     collapsible,
     entryFile,
+    descriptionFallback,
     ctx,
     frontmatter,
     depth,
@@ -270,6 +298,7 @@ async function buildEntryTree(params: BuildEntryTreeParams): Promise<ResolvedEnt
         sort,
         collapsible,
         entryFile,
+        descriptionFallback,
         ctx,
         frontmatter,
         depth: depth + 1,
@@ -283,8 +312,21 @@ async function buildEntryTree(params: BuildEntryTreeParams): Promise<ResolvedEnt
 
       const sectionLink = resolveSectionLink(entryFilePath, subPrefix, entryFile)
 
+      // Source a description from the subdir's overview page (or an
+      // entry-slug child) so its card on a parent landing isn't blank.
+      const sectionSource = match(sectionPage)
+        .with(P.nonNullable, (p) => p.source)
+        .otherwise(() => undefined)
+      const description = await resolveGroupDescription({
+        sourcePath: sectionSource,
+        children: sorted,
+        indexFile: entryFile,
+        fallback: descriptionFallback,
+      })
+
       return {
         title: sectionTitle,
+        description,
         link: sectionLink,
         collapsible: effectiveCollapsible,
         items: sorted,

--- a/packages/cli/src/lib/sync/sidebar/inject.ts
+++ b/packages/cli/src/lib/sync/sidebar/inject.ts
@@ -1,7 +1,6 @@
 import { ICON_COLORS, resolveOptionalIcon, serializeIcon } from '@ciderpress/config'
-import type { IconColor, Page, Workspace } from '@ciderpress/config'
+import type { DescriptionFallback, IconColor, Workspace } from '@ciderpress/config'
 import { match, P } from 'massaman/match'
-import { isNil, isNotNil } from 'massaman/predicate'
 
 import { linkToOutputPath } from '../resolve/path.ts'
 import type { ResolvedEntry } from '../types.ts'
@@ -19,19 +18,19 @@ import { buildWorkspaceCardJsx, generateLandingContent } from './landing.ts'
  * deterministic without a mutable counter.
  *
  * @param entries - Resolved entry tree to walk
- * @param configSections - Original config pages for metadata lookup
  * @param workspaces - Workspace items for generating workspace landing pages
+ * @param fallback - Strategy for sourcing child card descriptions from prose
  * @returns New resolved entry tree with landing pages injected
  */
 export function injectLandingPages(
   entries: readonly ResolvedEntry[],
-  configSections: readonly Page[],
-  workspaces: readonly Workspace[]
+  workspaces: readonly Workspace[],
+  fallback: DescriptionFallback
 ): readonly ResolvedEntry[] {
   const { entries: result } = injectMany({
     entries,
-    configSections,
     workspaces,
+    fallback,
     colorIndex: 0,
   })
   return result
@@ -46,8 +45,8 @@ export function injectLandingPages(
  */
 interface InjectFrame {
   readonly entries: readonly ResolvedEntry[]
-  readonly configSections: readonly Page[]
   readonly workspaces: readonly Workspace[]
+  readonly fallback: DescriptionFallback
   readonly colorIndex: number
 }
 
@@ -76,8 +75,8 @@ function injectMany(frame: InjectFrame): InjectResult {
     (acc, entry) => {
       const { entry: rebuilt, nextColorIndex } = injectOne({
         entry,
-        configSections: frame.configSections,
         workspaces: frame.workspaces,
+        fallback: frame.fallback,
         colorIndex: acc.nextColorIndex,
       })
       return {
@@ -96,8 +95,8 @@ function injectMany(frame: InjectFrame): InjectResult {
  */
 interface InjectOneFrame {
   readonly entry: ResolvedEntry
-  readonly configSections: readonly Page[]
   readonly workspaces: readonly Workspace[]
+  readonly fallback: DescriptionFallback
   readonly colorIndex: number
 }
 
@@ -122,13 +121,13 @@ interface InjectOneResult {
  * @returns Rebuilt entry and next color index
  */
 function injectOne(frame: InjectOneFrame): InjectOneResult {
-  const { entry, configSections, workspaces, colorIndex } = frame
+  const { entry, workspaces, fallback, colorIndex } = frame
 
   // Recurse into children first so the rebuilt subtree is available when
   // we decide whether to inject a landing page for this entry.
   const childResult = match(entry.items)
     .with(P.nonNullable, (items) =>
-      injectMany({ entries: items, configSections, workspaces, colorIndex })
+      injectMany({ entries: items, workspaces, fallback, colorIndex })
     )
     .otherwise(() => ({
       entries: undefined as readonly ResolvedEntry[] | undefined,
@@ -145,8 +144,9 @@ function injectOne(frame: InjectOneFrame): InjectOneResult {
   }
 
   const link = entry.link as string
-  const configSection = findConfigSection(configSections, link)
-  const description: string | undefined = resolveDescription(configSection)
+  // Group description is resolved once in the resolve layer (config >
+  // overview page > entry-slug child); reuse it for the landing intro.
+  const description = baseEntry.description
   const rebuiltItems = childResult.entries
   const hasSelfLinkedChild = checkHasSelfLinkedChild(rebuiltItems, link)
 
@@ -154,7 +154,7 @@ function injectOne(frame: InjectOneFrame): InjectOneResult {
     const color: IconColor = ICON_COLORS[childResult.nextColorIndex % ICON_COLORS.length]
     const children = rebuiltItems
     const page: ResolvedEntry['page'] = {
-      content: () => generateLandingContent(entry.title, description, children, color),
+      content: () => generateLandingContent(entry.title, description, children, color, fallback),
       outputPath: linkToOutputPath(link).replace(/\.md$/, '.mdx'),
       frontmatter: {},
     }
@@ -235,45 +235,6 @@ function generateWorkspaceLandingPage(
     .otherwise(() => '')
 
   return `${imports}# ${heading}\n${descLine}\n<WorkspaceGrid>\n${cards.join('\n')}\n</WorkspaceGrid>\n`
-}
-
-/**
- * Look up the original config Page by link for extracting metadata.
- *
- * @private
- * @param sections - Config pages to search
- * @param link - Link path to match
- * @returns Matching page, or undefined
- */
-function findConfigSection(sections: readonly Page[], link: string): Page | undefined {
-  const direct = sections.find((section) => section.path === link)
-  if (direct) {
-    return direct
-  }
-  const nested = sections
-    .filter((section) => isNotNil(section.pages))
-    .map((section) => findConfigSection(section.pages as readonly Page[], link))
-    .find((result) => isNotNil(result))
-  return nested
-}
-
-/**
- * Extract description from a config page.
- *
- * @private
- * @param configSection - Optional config page
- * @returns Description string, or undefined
- */
-function resolveDescription(configSection: Page | undefined): string | undefined {
-  if (isNil(configSection)) {
-    return undefined
-  }
-
-  if (configSection.description) {
-    return configSection.description
-  }
-
-  return undefined
 }
 
 /**

--- a/packages/cli/src/lib/sync/sidebar/landing.ts
+++ b/packages/cli/src/lib/sync/sidebar/landing.ts
@@ -1,11 +1,9 @@
-import fs from 'node:fs/promises'
-
 import { resolveOptionalIcon, serializeIcon } from '@ciderpress/config'
-import type { IconColor, SerializedIcon } from '@ciderpress/config'
+import type { DescriptionFallback, IconColor, SerializedIcon } from '@ciderpress/config'
 import { match, P } from 'massaman/match'
 import { isNotNil, isString } from 'massaman/predicate'
 
-import { parse as parseFrontmatter } from '../frontmatter.ts'
+import { extractFileDescription } from '../resolve/description.ts'
 import type { ResolvedEntry } from '../types.ts'
 
 /**
@@ -58,13 +56,16 @@ export interface WorkspaceCardData {
  * @param description - Optional section description
  * @param children - Resolved child entries
  * @param iconColor - Color theme for section card icons
+ * @param fallback - Strategy for sourcing a card description from prose
+ *   when a child's file has no frontmatter `description`
  * @returns MDX string with React component imports and JSX elements
  */
 export async function generateLandingContent(
   sectionText: string,
   description: string | undefined,
   children: readonly ResolvedEntry[],
-  iconColor: IconColor
+  iconColor: IconColor,
+  fallback: DescriptionFallback
 ): Promise<string> {
   const visible = children.filter((c) => !c.hidden && c.link)
   const useWorkspace = visible.some((c) => c.card)
@@ -78,12 +79,14 @@ export async function generateLandingContent(
     "'@ciderpress/ui/theme'\n\n"
 
   if (useWorkspace) {
-    const cards = await Promise.all(visible.map((child) => buildWorkspaceCard(child)))
+    const cards = await Promise.all(visible.map((child) => buildWorkspaceCard(child, fallback)))
     const grid = cards.join('\n')
     return `${imports}# ${sectionText}\n${descLine}\n<WorkspaceGrid>\n${grid}\n</WorkspaceGrid>\n`
   }
 
-  const cards = await Promise.all(visible.map((child) => buildSectionCard(child, iconColor)))
+  const cards = await Promise.all(
+    visible.map((child) => buildSectionCard(child, iconColor, fallback))
+  )
   const grid = cards.join('\n')
   return `${imports}# ${sectionText}\n${descLine}\n<SectionGrid>\n${grid}\n</SectionGrid>\n`
 }
@@ -121,11 +124,15 @@ export function buildWorkspaceCardJsx(data: WorkspaceCardData): string {
  *
  * @private
  * @param entry - Resolved entry with card metadata
+ * @param fallback - Strategy for sourcing a description from prose
  * @returns JSX string for a WorkspaceCard component
  */
-async function buildWorkspaceCard(entry: ResolvedEntry): Promise<string> {
+async function buildWorkspaceCard(
+  entry: ResolvedEntry,
+  fallback: DescriptionFallback
+): Promise<string> {
   const card = entry.card ?? {}
-  const description = card.description ?? (await resolveDescription(entry))
+  const description = card.description ?? (await resolveDescription(entry, fallback))
   const resolved = resolveOptionalIcon(card.icon)
 
   return buildWorkspaceCardJsx({
@@ -146,9 +153,14 @@ async function buildWorkspaceCard(entry: ResolvedEntry): Promise<string> {
  * @private
  * @param entry - Resolved entry to render as a card
  * @param iconColor - Color theme for the icon
+ * @param fallback - Strategy for sourcing a description from prose
  * @returns JSX string for a single SectionCard component
  */
-async function buildSectionCard(entry: ResolvedEntry, iconColor: IconColor): Promise<string> {
+async function buildSectionCard(
+  entry: ResolvedEntry,
+  iconColor: IconColor,
+  fallback: DescriptionFallback
+): Promise<string> {
   const hasChildren = entry.items && entry.items.length > 0
   const iconId = match(hasChildren)
     .with(true, () => 'pixelarticons:folder')
@@ -156,7 +168,8 @@ async function buildSectionCard(entry: ResolvedEntry, iconColor: IconColor): Pro
   const icon: SerializedIcon = match(iconColor)
     .with('purple', () => iconId as SerializedIcon)
     .otherwise(() => ({ id: iconId, color: iconColor }) as SerializedIcon)
-  const description = await resolveDescription(entry)
+  const card = entry.card ?? {}
+  const description = card.description ?? (await resolveDescription(entry, fallback))
 
   const baseProps = [
     `href="${entry.link}"`,
@@ -173,55 +186,34 @@ async function buildSectionCard(entry: ResolvedEntry, iconColor: IconColor): Pro
 
 /**
  * Resolve a description for a card.
- * Priority: card.description > source file frontmatter > first paragraph > page frontmatter.
+ * Priority: source file frontmatter/prose > resolved config/group description.
+ *
+ * Card-level `card.description` overrides are applied by the callers
+ * ({@link buildWorkspaceCard} / {@link buildSectionCard}) before this runs.
  *
  * @private
  * @param entry - Resolved entry to extract description from
+ * @param fallback - Strategy for sourcing a description from prose
  * @returns Description string, or undefined if none found
  */
-async function resolveDescription(entry: ResolvedEntry): Promise<string | undefined> {
-  if (isNotNil(entry.page) && entry.page.source) {
-    try {
-      const desc = await extractDescription(entry.page.source)
-      if (desc) {
-        return desc
-      }
-    } catch {
-      // ignore
+async function resolveDescription(
+  entry: ResolvedEntry,
+  fallback: DescriptionFallback
+): Promise<string | undefined> {
+  if (isNotNil(entry.page) && isNotNil(entry.page.source)) {
+    const desc = await extractFileDescription(entry.page.source, fallback)
+    if (isNotNil(desc)) {
+      return desc
     }
   }
 
-  // Config-level description as fallback (no file, or file has no description)
-  if (entry.description) {
+  // Resolved config/group description as fallback (virtual page, or file
+  // with no description). Populated by the resolve layer for group entries.
+  if (isNotNil(entry.description)) {
     return entry.description
   }
 
   return undefined
-}
-
-/**
- * Extract a short description from a markdown file.
- * Checks frontmatter `description` first, then first paragraph after heading.
- *
- * @private
- * @param sourcePath - Absolute path to the markdown file
- * @returns Description string, or undefined if none found
- */
-async function extractDescription(sourcePath: string): Promise<string | undefined> {
-  const raw = await fs.readFile(sourcePath, 'utf8')
-  const { data, content } = parseFrontmatter(raw)
-
-  if (data.description) {
-    return String(data.description)
-  }
-
-  const lines = content.split('\n')
-  const headingIdx = lines.findIndex((l) => l.startsWith('#'))
-  const para: readonly string[] = resolveParagraph(lines, headingIdx)
-
-  if (para.length > 0) {
-    return para.join(' ')
-  }
 }
 
 /**
@@ -242,47 +234,6 @@ function escapeJsxProp(str: string): string {
     .replaceAll('"', '&quot;')
     .replaceAll('{', '&#123;')
     .replaceAll('}', '&#125;')
-}
-
-/**
- * Extract the first non-empty paragraph after a heading from markdown lines.
- *
- * @private
- * @param lines - Array of markdown lines
- * @param headingIdx - Index of the heading line (-1 if none found)
- * @returns Array of trimmed paragraph lines
- */
-function resolveParagraph(lines: readonly string[], headingIdx: number): readonly string[] {
-  if (headingIdx === -1) {
-    return []
-  }
-
-  return lines
-    .slice(headingIdx + 1)
-    .reduce<{ readonly done: boolean; readonly result: readonly string[] }>(
-      (acc, line) => {
-        if (acc.done) {
-          return acc
-        }
-        if (line.startsWith('#')) {
-          return { done: true, result: acc.result }
-        }
-
-        const trimmed = line.trim()
-        if (trimmed === '' && acc.result.length > 0) {
-          return { done: true, result: acc.result }
-        }
-        if (trimmed === '') {
-          return acc
-        }
-        if (trimmed.startsWith('<') || trimmed.startsWith('---')) {
-          return acc
-        }
-
-        return { done: false, result: [...acc.result, trimmed] }
-      },
-      { done: false, result: [] }
-    ).result
 }
 
 /**

--- a/packages/cli/src/lib/sync/sidebar/sidebar.test.ts
+++ b/packages/cli/src/lib/sync/sidebar/sidebar.test.ts
@@ -29,7 +29,7 @@ describe('injectLandingPages()', () => {
       items: [child],
     }
 
-    const [result] = injectLandingPages([section], [], [])
+    const [result] = injectLandingPages([section], [], 'firstParagraph')
 
     expect(result.page).toBeDefined()
     expect(result.page!.outputPath).toMatch(/\.mdx$/)
@@ -50,7 +50,7 @@ describe('injectLandingPages()', () => {
       items: [child],
     }
 
-    const [result] = injectLandingPages([section], [], [])
+    const [result] = injectLandingPages([section], [], 'firstParagraph')
 
     expect(result.page).toBe(existingPage)
   })
@@ -72,7 +72,7 @@ describe('injectLandingPages()', () => {
       items: [nested],
     }
 
-    const [result] = injectLandingPages([section], [], [])
+    const [result] = injectLandingPages([section], [], 'firstParagraph')
 
     const [rebuiltNested] = result.items!
     expect(rebuiltNested.page).toBeDefined()

--- a/packages/config/schemas/schema.json
+++ b/packages/config/schemas/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://raw.githubusercontent.com/thebytefarm/ciderpress/v1.0.0-rc.5/packages/config/schemas/schema.json",
+  "$id": "https://raw.githubusercontent.com/thebytefarm/ciderpress/v1.0.0-rc.6/packages/config/schemas/schema.json",
   "title": "Ciderpress Configuration",
   "description": "Configuration file for ciderpress documentation framework",
   "type": "object",
@@ -707,6 +707,13 @@
               },
               "indexFile": {
                 "type": "string"
+              },
+              "descriptionFallback": {
+                "type": "string",
+                "enum": [
+                  "firstParagraph",
+                  "none"
+                ]
               }
             },
             "additionalProperties": false
@@ -1084,6 +1091,13 @@
               },
               "indexFile": {
                 "type": "string"
+              },
+              "descriptionFallback": {
+                "type": "string",
+                "enum": [
+                  "firstParagraph",
+                  "none"
+                ]
               }
             },
             "additionalProperties": false
@@ -1511,6 +1525,13 @@
                     },
                     "indexFile": {
                       "type": "string"
+                    },
+                    "descriptionFallback": {
+                      "type": "string",
+                      "enum": [
+                        "firstParagraph",
+                        "none"
+                      ]
                     }
                   },
                   "additionalProperties": false
@@ -3027,6 +3048,13 @@
           "items": {
             "type": "string"
           }
+        },
+        "descriptionFallback": {
+          "type": "string",
+          "enum": [
+            "firstParagraph",
+            "none"
+          ]
         }
       },
       "additionalProperties": false
@@ -3485,6 +3513,13 @@
             },
             "indexFile": {
               "type": "string"
+            },
+            "descriptionFallback": {
+              "type": "string",
+              "enum": [
+                "firstParagraph",
+                "none"
+              ]
             }
           },
           "additionalProperties": false

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -32,6 +32,7 @@ export type {
   WorkspaceGroup,
   TitleConfig,
   SortStrategy,
+  DescriptionFallback,
   ButtonConfig,
   BrandConfig,
   BannerConfig,

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -39,6 +39,7 @@ import type {
   ButtonConfig,
   CardConfig,
   CopyrightConfig,
+  DescriptionFallback,
   DevServerConfig,
   DiscoverConfig,
   EditLinkConfig,
@@ -232,6 +233,8 @@ const imageSourceSchema = z.union([
 
 const sortStrategySchema = z.union([z.enum(['default', 'alpha', 'filename', 'none']), sortFnSchema])
 
+const descriptionFallbackSchema = z.enum(['firstParagraph', 'none'])
+
 const LOADER_TIMING_MESSAGE =
   'loader.maxDisplayMs must be at least minDisplayMs + 200ms (fade transition)'
 
@@ -320,6 +323,7 @@ const pageSchema: z.ZodType<Page> = z.lazy(() =>
           recursive: z.boolean().optional(),
           ignore: z.array(z.string()).optional(),
           indexFile: z.string().optional(),
+          descriptionFallback: descriptionFallbackSchema.optional(),
         })
         .strict()
         .optional(),
@@ -345,6 +349,7 @@ const workspaceSchema = z
         recursive: z.boolean().optional(),
         ignore: z.array(z.string()).optional(),
         indexFile: z.string().optional(),
+        descriptionFallback: descriptionFallbackSchema.optional(),
       })
       .strict()
       .optional(),
@@ -629,6 +634,7 @@ const feedbackConfigSchema = z
 const discoverConfigSchema = z
   .object({
     ignore: z.array(z.string()).optional(),
+    descriptionFallback: descriptionFallbackSchema.optional(),
   })
   .strict()
 
@@ -820,6 +826,8 @@ const _guardIconConfig: z.ZodType<IconConfig> = iconConfigSchema
 const _guardTitleConfig: z.ZodType<TitleConfig> = titleConfigSchema
 // oxlint-disable-next-line no-unused-vars -- compile-time type guard
 const _guardSortStrategy: z.ZodType<SortStrategy> = sortStrategySchema
+// oxlint-disable-next-line no-unused-vars -- compile-time type guard
+const _guardDescriptionFallback: z.ZodType<DescriptionFallback> = descriptionFallbackSchema
 // oxlint-disable-next-line no-unused-vars -- compile-time type guard
 const _guardHomeHeroConfig: z.ZodType<HomeHeroConfig> = homeHeroConfigSchema
 // oxlint-disable-next-line no-unused-vars -- compile-time type guard

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -407,6 +407,17 @@ export type SortStrategy =
   | ((a: ResolvedPage, b: ResolvedPage) => number)
 
 /**
+ * Strategy for sourcing a group's card/landing description when its
+ * overview file has no frontmatter `description`.
+ *
+ * - `'firstParagraph'` (default) — fall back to the first prose paragraph
+ *   after the heading.
+ * - `'none'` — require an explicit frontmatter `description`; never infer
+ *   one from body prose.
+ */
+export type DescriptionFallback = 'firstParagraph' | 'none'
+
+/**
  * Card appearance overrides — controls how a `Page` or workspace renders
  * as a card on a parent's auto-generated landing.
  */
@@ -567,6 +578,13 @@ export interface Page {
      * landing page (was `entryFile`).
      */
     readonly indexFile?: string
+    /**
+     * How to source this group's card/landing description when its
+     * overview file has no frontmatter `description`. Overrides the
+     * top-level `discover.descriptionFallback`. Defaults to
+     * `'firstParagraph'`.
+     */
+    readonly descriptionFallback?: DescriptionFallback
   }
   /**
    * Per-page OpenAPI integration — generates API operation pages under
@@ -650,6 +668,13 @@ export interface Workspace {
      * instead of generating an auto-landing.
      */
     readonly indexFile?: string
+    /**
+     * How to source this workspace's card/landing description when its
+     * overview file has no frontmatter `description`. Overrides the
+     * top-level `discover.descriptionFallback`. Defaults to
+     * `'firstParagraph'`.
+     */
+    readonly descriptionFallback?: DescriptionFallback
   }
   /**
    * Per-workspace OpenAPI integration.
@@ -1643,6 +1668,13 @@ export interface DiscoverConfig {
    * Global glob patterns excluded from every page's auto-discovery.
    */
   readonly ignore?: readonly string[]
+  /**
+   * Default strategy for sourcing a group's card/landing description when
+   * its overview file has no frontmatter `description`. A per-page
+   * `discover.descriptionFallback` overrides this. Defaults to
+   * `'firstParagraph'`.
+   */
+  readonly descriptionFallback?: DescriptionFallback
 }
 
 /**


### PR DESCRIPTION
## Summary

Auto-generated group landing pages left **nested-group cards blank** unless an explicit config `description` was set — even when the group had an `overview.md` (or `index.md`/`readme.md`). This wires up automatic description sourcing from a group's overview/root page, plus a config knob to control the inference.

The gap: a group's card/landing description was only ever sourced from the group's own `page.source` frontmatter or a config-level `description`. Auto-derived groups (glob `include`, no explicit `description`) never adopted their in-group overview, so their card fell back to an unset `entry.description` and rendered nothing.

### Fix

Resolve a group's description **once** in the sync resolve layer and reuse it for both the parent card and the group's own landing intro. Precedence (highest first):

`card.description` → `Page.description` → group overview frontmatter `description` → overview first paragraph

## Changes

**`@ciderpress/config`**
- New `discover.descriptionFallback: 'firstParagraph' | 'none'` on `Page.discover`, `Workspace.discover`, and the top-level `discover`. Defaults to `'firstParagraph'`; `'none'` requires an explicit frontmatter `description` and skips first-paragraph inference.
- Export `DescriptionFallback`. Regenerated `schemas/schema.json`.

**`@ciderpress/cli`**
- New `resolve/description.ts`: `extractFileDescription`, `findEntrySlugChild`, `resolveGroupDescription` (shared extraction, moved out of `landing.ts`).
- `resolve/index.ts` + `recursive.ts` populate `entry.description` for group entries from the overview page / entry-slug child / probed overview file.
- `inject.ts` now consumes the resolved `entry.description` (drops the fragile `findConfigSection` + `configSections` threading).
- Section cards now honor `card.description`, matching workspace cards.

**Docs**
- `docs/references/configuration.md` — documents the new field and the card-description precedence.

## Testing

- New `resolve/description.test.ts` (16 cases): frontmatter vs first-paragraph vs `none` fallback, entry-slug child selection/priority, `resolveGroupDescription` precedence.
- Existing `sidebar.test.ts` updated for the new `injectLandingPages` signature.
- Full suites green: `@ciderpress/cli` 243 tests, `@ciderpress/config` 48 tests.
- `pnpm typecheck` clean; targeted `oxlint`/`oxfmt` clean.
- End-to-end verified against a real fixture: a nested `API` group with `docs/api/overview.md` now renders `<SectionCard ... description="Typed REST endpoints for the platform." />` on its parent's landing (previously no `description` prop).

## Related

Fixes blank nested-group cards on auto-generated landings.