### PR TITLE
fix(packages/ui): register ELK layout loaders for Mermaid

### DIFF
--- a/.changeset/elk-layout.md
+++ b/.changeset/elk-layout.md
@@ -1,0 +1,5 @@
+---
+'@ciderpress/ui': minor
+---
+
+Register the ELK layout loaders for Mermaid. Diagrams that opt in with `layout: elk` now render instead of silently blanking. The ELK engine (and its worker) loads lazily in the browser only when a diagram requests it, so build output and edge/Cloudflare builds are unaffected.

--- a/docs/references/built-ins/mermaid.md
+++ b/docs/references/built-ins/mermaid.md
@@ -209,6 +209,44 @@ pie title Tech Stack
   "Other" : 10
 ```
 
+## ELK layout
+
+Flowcharts and state diagrams can opt into the [ELK](https://eclipse.dev/elk/) layout engine for tidier routing of large or dense graphs. Set `layout: elk` in the diagram's init directive — no configuration or extra imports needed.
+
+**Code**
+
+````md
+```mermaid
+---
+config:
+  layout: elk
+---
+graph TB
+  A[Ingest] --> B[Parse]
+  A --> C[Validate]
+  B --> D[Render]
+  C --> D
+  D --> E[Publish]
+```
+````
+
+**Output**
+
+```mermaid
+---
+config:
+  layout: elk
+---
+graph TB
+  A[Ingest] --> B[Parse]
+  A --> C[Validate]
+  B --> D[Render]
+  C --> D
+  D --> E[Publish]
+```
+
+The ELK engine loads lazily in the browser only when a diagram requests it, so it adds nothing to your build output or to diagrams that use the default layout.
+
 ## All supported types
 
 | Type                | Directive              |

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -18,12 +18,13 @@ component. Currently:
 Because Rspress's webpack compiles these files independently, they can **only
 import packages that Rspress's webpack can resolve**:
 
-| Allowed              | Forbidden                                       |
-| -------------------- | ----------------------------------------------- |
-| `react`, `react-dom` | `ts-pattern`                                    |
-| `mermaid`            | `es-toolkit`                                    |
-| Relative CSS imports | Any `@ciderpress/*` workspace package           |
-| Other Rspress deps   | Any dependency not in Rspress's resolve context |
+| Allowed                  | Forbidden                                       |
+| ------------------------ | ----------------------------------------------- |
+| `react`, `react-dom`     | `ts-pattern`                                    |
+| `mermaid`                | `es-toolkit`                                    |
+| `@mermaid-js/layout-elk` | Any `@ciderpress/*` workspace package           |
+| Relative CSS imports     | Any dependency not in Rspress's resolve context |
+| Other Rspress deps       |                                                 |
 
 ### Style rules relaxed
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -67,6 +67,7 @@
     "@iconify-json/skill-icons": "^1.2.4",
     "@iconify-json/vscode-icons": "^1.2.65",
     "@iconify/react": "^6.0.2",
+    "@mermaid-js/layout-elk": "^0.2.2",
     "clsx": "^2.1.1",
     "katex": "^0.17.0",
     "massaman": "catalog:",

--- a/packages/ui/src/plugins/mermaid/MermaidRenderer.tsx
+++ b/packages/ui/src/plugins/mermaid/MermaidRenderer.tsx
@@ -15,11 +15,34 @@
 
 // oxlint-disable no-ternary
 
+import elkLayouts from '@mermaid-js/layout-elk'
 import mermaid from 'mermaid'
 import type { MermaidConfig } from 'mermaid'
 import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 
 import './mermaid.css'
+
+// ELK layout support. Diagrams that opt in with `layout: elk` (via frontmatter or
+// `%%{init: {'layout': 'elk'}}%%`) need the ELK loaders registered before render,
+// or mermaid.render() throws and the diagram silently blanks. `elkLayouts` is an
+// array of lazy loaders (`() => import(...)`), so elkjs — and its web worker —
+// only load client-side when a diagram actually uses ELK, never at build/SSR time.
+// Registration itself is a cheap, edge-safe registry push. We guard on a module
+// flag so React re-mounts / StrictMode double-invokes register exactly once.
+const elkState = { registered: false }
+
+/**
+ * Register the ELK layout loaders with mermaid, exactly once per module load.
+ *
+ * @private
+ */
+function ensureElkRegistered(): void {
+  if (elkState.registered) {
+    return
+  }
+  elkState.registered = true
+  mermaid.registerLayoutLoaders(elkLayouts)
+}
 
 interface MermaidRendererProps {
   readonly code: string
@@ -243,6 +266,8 @@ function MermaidRenderer(props: MermaidRendererProps): React.ReactElement | null
   const isPreview = tab === 'preview'
 
   const renderMermaid = useCallback(async () => {
+    ensureElkRegistered()
+
     const hasDarkClass = document.documentElement.classList.contains('dark')
 
     const mermaidConfig: MermaidConfig = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,6 +441,9 @@ importers:
       '@iconify/react':
         specifier: ^6.0.2
         version: 6.0.2(react@19.2.7)
+      '@mermaid-js/layout-elk':
+        specifier: ^0.2.2
+        version: 0.2.2(mermaid@11.16.0)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1948,6 +1951,11 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@mermaid-js/layout-elk@0.2.2':
+    resolution: {integrity: sha512-vnH3gtqfhyBiRVKNpT8iDENTw18q/OF0GF/SfYfHN43KZpu+6eZDEOMHTfNYAkpmUWJNgtRQFIS6BTc7vH/DYQ==}
+    peerDependencies:
+      mermaid: ^11.0.2
 
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
@@ -4402,6 +4410,9 @@ packages:
 
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
+
+  elkjs@0.9.3:
+    resolution: {integrity: sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -8940,6 +8951,12 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
 
+  '@mermaid-js/layout-elk@0.2.2(mermaid@11.16.0)':
+    dependencies:
+      d3: 7.9.0
+      elkjs: 0.9.3
+      mermaid: 11.16.0
+
   '@mermaid-js/parser@1.2.0':
     dependencies:
       '@chevrotain/types': 11.1.2
@@ -11276,6 +11293,8 @@ snapshots:
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.389: {}
+
+  elkjs@0.9.3: {}
 
   emoji-regex@10.6.0: {}
 


### PR DESCRIPTION
## Summary

Mermaid diagrams that opt into the ELK layout engine (`layout: elk` via frontmatter or an init directive) rendered nothing. Mermaid v11 ships the ELK engine as a separate package and the loaders were never registered, so `mermaid.render()` threw "layout elk not found" — the renderer's `catch` returned `null` and the diagram silently blanked.

## Changes

- Add `@mermaid-js/layout-elk@^0.2.2` (peer-matches installed `mermaid@11.16.0`) to `@ciderpress/ui`.
- Register the ELK loaders once, client-side, in `MermaidRenderer`'s render path (guarded by a module flag so StrictMode / re-mounts register exactly once).
- Document ELK usage in `docs/references/built-ins/mermaid.md`.
- Update the raw-copied-components allowed-imports table in `packages/ui/AGENTS.md`.

## Cloudflare / edge safety

The package's top-level export is a small array of **lazy** loaders (`async () => await import(...)`). `elkjs` and its web worker live behind that dynamic import, so they only load in the browser when a diagram actually requests ELK — nothing lands in the SSR/build bundle. Registration itself is a cheap registry push; no native deps, no worker spawned at build time. Verified the eager import is ~543 bytes with no `elkjs` reference.

## Testing

- `pnpm build --filter @ciderpress/ui` and `pnpm check --filter @ciderpress/ui` pass (0 errors).
- Drove the live docs site headless with Playwright + system Chrome against the mermaid reference page: all 8 diagrams (including the new `layout: elk` example) rendered SVGs with no render errors. The ELK diagram produced a 16KB, 5-node SVG — proving the loader resolved and ran.

## Related

Follow-up (not in this PR): bundle `@rspress/plugin-sitemap` and `@rspress/plugin-llms` (both v2-native and edge-safe).