### PR TITLE
chore(ci): bump GitHub Actions to latest majors on Node 24

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: codspeed-macro
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -18,13 +18,13 @@ jobs:
     env:
       ARGOS_TOKEN: ${{ secrets.ARGOS_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -34,7 +34,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -68,7 +68,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: e2e/.playwright/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -29,11 +29,11 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'

--- a/.github/workflows/vscode-release.yml
+++ b/.github/workflows/vscode-release.yml
@@ -16,11 +16,11 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '24'
           cache: 'pnpm'


### PR DESCRIPTION
## Summary

The release workflow logged `Node.js 20 is deprecated ... actions target Node.js 20 but are being forced to run on Node.js 24` for `actions/checkout@v4`, `actions/setup-node@v4`, and `pnpm/action-setup@v4`. Those pins bundle the Node 20 action runtime; the fix is bumping each action to its current major, all of which ship on the Node 24 runtime. No "force" hack is needed.

The `node-version: '24'` used by job *steps* was already correct — this only concerns the *actions' own* runtime.

## Changes

Verified each target's latest major and confirmed its `runs.using` is `node24` before bumping:

| Action | Before | After | Runtime |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | **v7** | node24 |
| `actions/setup-node` | v4 | **v7** | node24 |
| `pnpm/action-setup` | v4 | **v6** | node24 |
| `actions/cache` | v4 | **v6** | node24 |
| `actions/upload-artifact` | v4 | **v7** | node24 |

Left unchanged (already current + off Node 20):

- `changesets/action@v1` — floating major already resolves to v1.9.0 (`node24`)
- `CodSpeedHQ/action@v4` — latest major, `composite`

`pnpm/action-setup@v6` resolves the pnpm version from the root `packageManager` field (`pnpm@10.32.0`), which is already present, so no `version` input is required.

## Testing

- `pnpm changeset status --since=origin/main` exits 0 (workflow-only change, no package release).
- YAML changes are single-token version bumps; structure unchanged.
- CI on this PR exercises the bumped `checkout`/`setup-node`/`pnpm-action-setup`/`cache`/`upload-artifact` actions end to end.

## Related Issues

_None._